### PR TITLE
Remove unnecessary after values from release workflow

### DIFF
--- a/.mint/release.yml
+++ b/.mint/release.yml
@@ -72,7 +72,6 @@ tasks:
       ssh-add ~/.ssh/id_ed25519
   - key: draft-full-version-release
     use: [ensure-release-not-published, setup-git-ssh]
-    after: extract-version-details
     run: |
       full_version="${{ tasks.extract-version-details.kvOutputs.full-version }}"
       echo "Creating release ${full_version} if it does not exist"
@@ -140,7 +139,6 @@ tasks:
       nix develop --command mage
   - key: upload-linux-amd64-to-release
     use: build-mint-linux-amd64
-    after: extract-version-details
     run: |
       github_asset_name=$(echo "mint-linux-x86_64" | tr '[:upper:]' '[:lower:]')
       mv "mint" "$github_asset_name"
@@ -157,7 +155,6 @@ tasks:
       nix develop --command mage
   - key: upload-linux-arm64-to-release
     use: build-mint-linux-arm64
-    after: extract-version-details
     run: |
       github_asset_name=$(echo "mint-linux-aarch64" | tr '[:upper:]' '[:lower:]')
       mv "mint" "$github_asset_name"
@@ -190,7 +187,6 @@ tasks:
       RWX_APPLE_APP_STORE_CONNECT_API_KEY: ${{ secrets.RWX_APPLE_APP_STORE_CONNECT_API_KEY }}
   - key: upload-darwin-amd64-to-release
     use: notarize-amd64-binary
-    after: extract-version-details
     run: |
       github_asset_name=$(echo "mint-darwin-x86_64" | tr '[:upper:]' '[:lower:]')
       mv "mint" "$github_asset_name"
@@ -223,7 +219,6 @@ tasks:
       RWX_APPLE_APP_STORE_CONNECT_API_KEY: ${{ secrets.RWX_APPLE_APP_STORE_CONNECT_API_KEY }}
   - key: upload-darwin-arm64-to-release
     use: notarize-arm64-binary
-    after: extract-version-details
     run: |
       github_asset_name=$(echo "mint-darwin-aarch64" | tr '[:upper:]' '[:lower:]')
       mv "mint" "$github_asset_name"
@@ -240,7 +235,6 @@ tasks:
       nix develop --command mage
   - key: upload-windows-amd64-to-release
     use: build-mint-windows-amd64
-    after: extract-version-details
     run: |
       github_asset_name=$(echo "mint-windows-x86_64.exe" | tr '[:upper:]' '[:lower:]')
       mv "mint.exe" "$github_asset_name"
@@ -257,7 +251,6 @@ tasks:
       nix develop --command mage
   - key: upload-windows-arm64-to-release
     use: build-mint-windows-arm64
-    after: extract-version-details
     run: |
       github_asset_name=$(echo "mint-windows-aarch64.exe" | tr '[:upper:]' '[:lower:]')
       mv "mint.exe" "$github_asset_name"
@@ -291,7 +284,6 @@ tasks:
 
   - key: update-aliased-version-release
     use: [ensure-release-not-published, setup-git-ssh, ensure-uploads-succeeded]
-    after: extract-version-details
     run: |
       aliased_version="${{ tasks.extract-version-details.kvOutputs.aliased-version }}"
       if [[ $aliased_version == "_" ]]; then


### PR DESCRIPTION
These were just a workaround while we fixed a bug with `after`, and now that bug has been fixed.