### PR TITLE
Parse error messages from the API correctly

### DIFF
--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -86,8 +86,10 @@ func (c Client) InitiateRun(cfg InitiateRunConfig) (*url.URL, error) {
 // extractErrorMessage is a small helper function for parsing an API error message
 func extractErrorMessage(reader io.Reader) string {
 	errorStruct := struct {
-		Error struct {
-			Message string
+		Result struct {
+			Data struct {
+				Error string
+			}
 		}
 	}{}
 
@@ -95,5 +97,5 @@ func extractErrorMessage(reader io.Reader) string {
 		return ""
 	}
 
-	return errorStruct.Error.Message
+	return errorStruct.Result.Data.Error
 }


### PR DESCRIPTION
When we have known errors (i.e. the kind of errors we actually want to show via the CLI), they're now nested under `result.data.error`, not `error.message`. This change will resolve all the "Unable to call Mint API - 400 Bad Request" errors we currently get in the CLI.

We're missing some test coverage here but I want to chat with Pierre about how we should test this, and I'd like to get this (manually tested) fix in place ahead of that.