### PR TITLE
Remove -y from apt-get calls

### DIFF
--- a/.mint/release.yml
+++ b/.mint/release.yml
@@ -55,7 +55,7 @@ tasks:
       && sudo chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg \
       && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null \
       && sudo apt-get update \
-      && sudo apt-get install gh -y
+      && sudo apt-get install gh
   - key: ensure-release-not-published
     use: install-gh-cli
     run: |
@@ -113,8 +113,8 @@ tasks:
     run: npm install yaml@2.3.4
   - key: install-zip
     run: |
-      sudo apt-get -y update
-      sudo apt-get -y install zip
+      sudo apt-get update
+      sudo apt-get install zip
 
   # These won't work until we enable dependencies between dynamic tasks
   # - key: generate-build-tasks


### PR DESCRIPTION
This is no longer required with the base image changes.
