### PR TITLE
Replace --init-parameter with --init for brevity and to match the run definition triggers

### DIFF
--- a/.mint/continuous_integration.yml
+++ b/.mint/continuous_integration.yml
@@ -67,8 +67,8 @@ tasks:
     if: ${{ init.branch == "main" }}
     run: |
       ./mint run -f .mint/release.yml \
-        --init-parameter "kind=unstable" \
-        --init-parameter "commit=${{ init.commit }}" \
-        --init-parameter "version=UNSTABLE"
+        --init "kind=unstable" \
+        --init "commit=${{ init.commit }}" \
+        --init "version=UNSTABLE"
     env:
       RWX_ACCESS_TOKEN: ${{ secrets.RWX_ACCESS_TOKEN }}

--- a/cmd/mint/run.go
+++ b/cmd/mint/run.go
@@ -65,7 +65,6 @@ var (
 				return err
 			}
 
-
 			if Json {
 				runResultJson, err := json.Marshal(runResult)
 				if err != nil {
@@ -98,7 +97,7 @@ func init() {
 	}
 
 	runCmd.Flags().BoolVar(&NoCache, "no-cache", false, "do not read or write to the cache")
-	runCmd.Flags().StringArrayVar(&InitParameters, "init-parameter", []string{}, "initialization parameters for the run, available in the `init` context. Can be specified multiple times")
+	runCmd.Flags().StringArrayVar(&InitParameters, "init", []string{}, "initialization parameters for the run, available in the `init` context. Can be specified multiple times")
 	runCmd.Flags().StringVarP(&MintFilePath, "file", "f", "", "a Mint config file to use for sourcing task definitions")
 	runCmd.Flags().StringVar(&AccessToken, "access-token", os.Getenv("RWX_ACCESS_TOKEN"), "the access token for Mint")
 	runCmd.Flags().StringVar(&MintDirectory, "dir", ".mint", "the directory containing your mint task definitions. By default, this is used to source task definitions")


### PR DESCRIPTION
`--init-parameter` is pretty verbose and we use `init:` elsewhere (in the run definitions). This is a breaking change, but I'll update usage once merged and released.