### PR TITLE
Support targeting multiple task keys

### DIFF
--- a/cmd/mint/run.go
+++ b/cmd/mint/run.go
@@ -28,7 +28,6 @@ var (
 	service  cli.Service
 
 	runCmd = &cobra.Command{
-		Args: cobra.MaximumNArgs(1),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			c, err := client.New(client.Config{AccessToken: AccessToken, Host: mintHost})
 			if err != nil {
@@ -43,9 +42,9 @@ var (
 			return nil
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			targetedTask := ""
-			if len(args) == 1 {
-				targetedTask = args[0]
+			var targetedTasks []string
+			if len(args) >= 0 {
+				targetedTasks = args
 			}
 
 			initParams, err := parseInitParameters(InitParameters)
@@ -59,7 +58,7 @@ var (
 				MintDirectory:  MintDirectory,
 				MintFilePath:   MintFilePath,
 				NoCache:        NoCache,
-				TargetedTask:   targetedTask,
+				TargetedTasks:  targetedTasks,
 			})
 			if err != nil {
 				return err

--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -25,7 +25,7 @@ type InitiateRunConfig struct {
 	MintDirectory  string
 	MintFilePath   string
 	NoCache        bool
-	TargetedTask   string
+	TargetedTasks  []string
 }
 
 func (c InitiateRunConfig) Validate() error {

--- a/internal/cli/service.go
+++ b/internal/cli/service.go
@@ -58,7 +58,7 @@ func (s Service) InitiateRun(cfg InitiateRunConfig) (*client.InitiateRunResult, 
 	runResult, err := s.Client.InitiateRun(client.InitiateRunConfig{
 		InitializationParameters: cfg.InitParameters,
 		TaskDefinitions:          taskDefinitions,
-		TargetedTaskKey:          cfg.TargetedTask,
+		TargetedTaskKeys:         cfg.TargetedTasks,
 		UseCache:                 !cfg.NoCache,
 	})
 	if err != nil {

--- a/internal/cli/service_test.go
+++ b/internal/cli/service_test.go
@@ -66,7 +66,7 @@ var _ = Describe("CLI Service", func() {
 					return &client.InitiateRunResult{
 						RunId: "785ce4e8-17b9-4c8b-8869-a55e95adffe7",
 						RunURL: "https://mint.rwx.com/rwx/runs/785ce4e8-17b9-4c8b-8869-a55e95adffe7",
-						TargetedTaskKey: "",
+						TargetedTaskKeys: []string{},
 						DefinitionPath: ".mint/mint.yml",
 					}, nil
 				}
@@ -93,7 +93,7 @@ var _ = Describe("CLI Service", func() {
 						return &client.InitiateRunResult{
 							RunId: "785ce4e8-17b9-4c8b-8869-a55e95adffe7",
 							RunURL: "https://mint.rwx.com/rwx/runs/785ce4e8-17b9-4c8b-8869-a55e95adffe7",
-							TargetedTaskKey: "",
+							TargetedTaskKeys: []string{},
 							DefinitionPath: ".mint/mint.yml",
 						}, nil
 					}
@@ -104,17 +104,17 @@ var _ = Describe("CLI Service", func() {
 
 			Context("and an optional task key argument", func() {
 				BeforeEach(func() {
-					runConfig.TargetedTask = fmt.Sprintf("%d", GinkgoRandomSeed())
+					runConfig.TargetedTasks = []string{fmt.Sprintf("%d", GinkgoRandomSeed())}
 
 					mockClient.MockInitiateRun = func(cfg client.InitiateRunConfig) (*client.InitiateRunResult, error) {
 						Expect(cfg.TaskDefinitions).To(HaveLen(1))
 						Expect(cfg.TaskDefinitions[0].Path).To(Equal(runConfig.MintFilePath))
-						Expect(cfg.TargetedTaskKey).To(Equal(fmt.Sprintf("%d", GinkgoRandomSeed())))
+						Expect(cfg.TargetedTaskKeys).To(Equal([]string{fmt.Sprintf("%d", GinkgoRandomSeed())}))
 						receivedFileContent = cfg.TaskDefinitions[0].FileContents
 						return &client.InitiateRunResult{
 							RunId: "785ce4e8-17b9-4c8b-8869-a55e95adffe7",
 							RunURL: "https://mint.rwx.com/rwx/runs/785ce4e8-17b9-4c8b-8869-a55e95adffe7",
-							TargetedTaskKey: "",
+							TargetedTaskKeys: []string{},
 							DefinitionPath: ".mint/mint.yml",
 						}, nil
 					}
@@ -194,7 +194,7 @@ var _ = Describe("CLI Service", func() {
 						return &client.InitiateRunResult{
 							RunId: "785ce4e8-17b9-4c8b-8869-a55e95adffe7",
 							RunURL: "https://mint.rwx.com/rwx/runs/785ce4e8-17b9-4c8b-8869-a55e95adffe7",
-							TargetedTaskKey: "",
+							TargetedTaskKeys: []string{},
 							DefinitionPath: ".mint/mint.yml",
 						}, nil
 					}

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -67,10 +67,10 @@ func (c Client) InitiateRun(cfg InitiateRunConfig) (*InitiateRunResult, error) {
 	}
 
 	respBody := struct {
-		RunId           string
-		RunURL          string
-		TargetedTaskKey string
-		DefinitionPath  string
+		RunId            string
+		RunURL           string
+		TargetedTaskKeys []string
+		DefinitionPath   string
 	}{}
 
 	if err := json.NewDecoder(resp.Body).Decode(&respBody); err != nil {
@@ -80,7 +80,7 @@ func (c Client) InitiateRun(cfg InitiateRunConfig) (*InitiateRunResult, error) {
 	return &InitiateRunResult{
 		RunId: respBody.RunId,
 		RunURL: respBody.RunURL,
-		TargetedTaskKey: respBody.TargetedTaskKey,
+		TargetedTaskKeys: respBody.TargetedTaskKeys,
 		DefinitionPath: respBody.DefinitionPath,
 	}, nil
 }

--- a/internal/client/config.go
+++ b/internal/client/config.go
@@ -24,15 +24,15 @@ func (c Config) Validate() error {
 type InitiateRunConfig struct {
 	InitializationParameters map[string]string
 	TaskDefinitions          []TaskDefinition
-	TargetedTaskKey          string `json:",omitempty"`
+	TargetedTaskKeys         []string `json:",omitempty"`
 	UseCache                 bool
 }
 
 type InitiateRunResult struct {
-	RunId           string
-	RunURL          string
-	TargetedTaskKey string
-	DefinitionPath  string
+	RunId            string
+	RunURL           string
+	TargetedTaskKeys []string
+	DefinitionPath   string
 }
 
 func (c InitiateRunConfig) Validate() error {


### PR DESCRIPTION
Previously `mint abc def` would return
> Error: accepts at most 1 arg(s), received 2

Now this successfully sends up both `abc` and `def` as targeted tasks.

This depends on related Cloud and Mint PRs to be merged