### PR TITLE
Add mint api base path

### DIFF
--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 
 	"github.com/pkg/errors"
 )
@@ -13,6 +14,7 @@ import (
 // Client is an API Client for Mint
 type Client struct {
 	RoundTrip func(*http.Request) (*http.Response, error)
+	Host      string
 }
 
 func New(cfg Config) (Client, error) {
@@ -28,12 +30,12 @@ func New(cfg Config) (Client, error) {
 		return http.DefaultClient.Do(req)
 	}
 
-	return Client{roundTrip}, nil
+	return Client{roundTrip, cfg.Host}, nil
 }
 
-// InitiateRun sends a request to Mint for starting a new runn
+// InitiateRun sends a request to Mint for starting a new run
 func (c Client) InitiateRun(cfg InitiateRunConfig) (*InitiateRunResult, error) {
-	endpoint := "/api/runs"
+	endpoint := c.mintEndpoint("/api/runs")
 
 	if err := cfg.Validate(); err != nil {
 		return nil, errors.Wrap(err, "validation failed")
@@ -78,10 +80,10 @@ func (c Client) InitiateRun(cfg InitiateRunConfig) (*InitiateRunResult, error) {
 	}
 
 	return &InitiateRunResult{
-		RunId: respBody.RunId,
-		RunURL: respBody.RunURL,
+		RunId:            respBody.RunId,
+		RunURL:           respBody.RunURL,
 		TargetedTaskKeys: respBody.TargetedTaskKeys,
-		DefinitionPath: respBody.DefinitionPath,
+		DefinitionPath:   respBody.DefinitionPath,
 	}, nil
 }
 
@@ -100,4 +102,12 @@ func extractErrorMessage(reader io.Reader) string {
 	}
 
 	return errorStruct.Result.Data.Error
+}
+
+// TODO(TS): Remove this once we're fully transitioned
+func (c Client) mintEndpoint(path string) string {
+	if !strings.Contains(c.Host, "cloud") {
+		return path
+	}
+	return "/mint" + path
 }

--- a/internal/client/client_suite_test.go
+++ b/internal/client/client_suite_test.go
@@ -1,0 +1,13 @@
+package client_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestClient(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Client Suite")
+}

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -1,0 +1,98 @@
+package client_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"net/http"
+
+	"github.com/rwx-research/mint-cli/internal/client"
+)
+
+var _ = Describe("Client", func() {
+	Describe("InitiateRun", func() {
+		Context("without a mint base path", func() {
+			It("uses an mint.rwx.com style endpoint", func() {
+				body := struct {
+					RunID            string   `json:"runId"`
+					RunURL           string   `json:"runUrl"`
+					TargetedTaskKeys []string `json:"targetedTaskKeys"`
+					DefinitionPath   string   `json:"definitionPath"`
+				}{
+					RunID:            "123",
+					RunURL:           "https://mint.rwx.com/runs/123",
+					TargetedTaskKeys: []string{},
+					DefinitionPath:   "foo",
+				}
+				bodyBytes, _ := json.Marshal(body)
+
+				roundTrip := func(req *http.Request) (*http.Response, error) {
+					Expect(req.URL.Path).To(Equal("/api/runs"))
+					return &http.Response{
+						Status:     "201 Created",
+						StatusCode: 201,
+						Body:       io.NopCloser(bytes.NewReader(bodyBytes)),
+					}, nil
+				}
+
+				c := client.Client{roundTrip, "mint.rwx.com"}
+
+				initRunConfig := client.InitiateRunConfig{
+					InitializationParameters: map[string]string{},
+					TaskDefinitions: []client.TaskDefinition{
+						{Path: "foo", FileContents: "echo 'bar'"},
+					},
+					TargetedTaskKeys: []string{},
+					UseCache:         false,
+				}
+
+				_, err := c.InitiateRun(initRunConfig)
+				Expect(err).To(BeNil())
+			})
+		})
+
+		Context("with a mint base path", func() {
+			It("prefixes the endpoint with the base path", func() {
+				body := struct {
+					RunID            string   `json:"runId"`
+					RunURL           string   `json:"runUrl"`
+					TargetedTaskKeys []string `json:"targetedTaskKeys"`
+					DefinitionPath   string   `json:"definitionPath"`
+				}{
+					RunID:            "123",
+					RunURL:           "https://mint.rwx.com/runs/123",
+					TargetedTaskKeys: []string{},
+					DefinitionPath:   "foo",
+				}
+				bodyBytes, _ := json.Marshal(body)
+
+				roundTrip := func(req *http.Request) (*http.Response, error) {
+					Expect(req.URL.Path).To(Equal("/mint/api/runs"))
+					return &http.Response{
+						Status:     "201 Created",
+						StatusCode: 201,
+						Body:       io.NopCloser(bytes.NewReader(bodyBytes)),
+					}, nil
+				}
+
+				c := client.Client{roundTrip, "cloud.rwx.com"}
+
+				initRunConfig := client.InitiateRunConfig{
+					InitializationParameters: map[string]string{},
+					TaskDefinitions: []client.TaskDefinition{
+						{Path: "foo", FileContents: "echo 'bar'"},
+					},
+					TargetedTaskKeys: []string{},
+					UseCache:         false,
+				}
+
+				_, err := c.InitiateRun(initRunConfig)
+				Expect(err).To(BeNil())
+			})
+		})
+	})
+})


### PR DESCRIPTION
Currently our endpoint looks like `<mint-host>/api/runs`.

With the move to cloud.rwx.com, it will look like `cloud.rwx.com/mint/api/runs`. To accommodate this, I need to conditionally modify the endpoint base path based on the host.

I kept it defaulting `MINT_HOST` to mint.rwx.com, but if you pass a custom `MINT_HOST` w/ cloud in it, it will perform the prefix.

I will replace these defaults with a cloud.rwx.com host and a /mint base path once cut over.

---

Please rip my go apart. It's been a minute.

![image](https://github.com/rwx-research/mint-cli/assets/62091/1fd611fa-486a-4ccc-9721-64a2e91bfc56)

Note run initiated using both mint hosts. Because cloud still has the old host as primary you can see it reports the run url using the soon to be deprecated host.
