### PR TITLE
Support equals signs in init parameters

### DIFF
--- a/cmd/mint/cmd_suite_test.go
+++ b/cmd/mint/cmd_suite_test.go
@@ -1,0 +1,13 @@
+package main_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestCli(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Cli Suite")
+}

--- a/cmd/mint/run.go
+++ b/cmd/mint/run.go
@@ -66,7 +66,7 @@ var (
 				targetedTasks = args
 			}
 
-			initParams, err := parseInitParameters(InitParameters)
+			initParams, err := ParseInitParameters(InitParameters)
 			if err != nil {
 				return errors.Wrap(err, "unable to parse init parameters")
 			}
@@ -125,16 +125,16 @@ func init() {
 
 // parseInitParameters converts a list of `key=value` pairs to a map. It also reads any `MINT_INIT_` variables from the
 // environment
-func parseInitParameters(params []string) (map[string]string, error) {
+func ParseInitParameters(params []string) (map[string]string, error) {
 	parsedParams := make(map[string]string)
 
 	parse := func(p string) error {
 		fields := strings.Split(p, "=")
-		if len(fields) != 2 {
+		if len(fields) < 2 {
 			return errors.Errorf("unable to parse %q", p)
 		}
 
-		parsedParams[fields[0]] = fields[1]
+		parsedParams[fields[0]] = strings.Join(fields[1:], "=")
 		return nil
 	}
 

--- a/cmd/mint/run_test.go
+++ b/cmd/mint/run_test.go
@@ -1,0 +1,28 @@
+package main_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	mint "github.com/rwx-research/mint-cli/cmd/mint"
+)
+
+var _ = Describe("ParseInitParameters", func() {
+	It("should parse init parameters", func() {
+		parsed, err := mint.ParseInitParameters([]string{"a=b", "c=d"})
+		Expect(err).To(BeNil())
+		Expect(parsed).To(Equal(map[string]string{"a": "b", "c": "d"}))
+	})
+
+	It("should parse init parameter with equals signs", func() {
+		parsed, err := mint.ParseInitParameters([]string{"a=b=c=d"})
+		Expect(err).To(BeNil())
+		Expect(parsed).To(Equal(map[string]string{"a": "b=c=d"}))
+	})
+
+	It("should error if init parameter is not equals-delimited", func() {
+		parsed, err := mint.ParseInitParameters([]string{"a"})
+		Expect(parsed).To(BeNil())
+		Expect(err).To(MatchError("unable to parse \"a\""))
+	})
+})


### PR DESCRIPTION
`--init "a=b=c"` should parse to a key of `a` and value of `b=c`.
