### PR TITLE
Fixes parsing errors from Cloud

### DIFF
--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -91,16 +91,12 @@ func (c Client) InitiateRun(cfg InitiateRunConfig) (*InitiateRunResult, error) {
 // extractErrorMessage is a small helper function for parsing an API error message
 func extractErrorMessage(reader io.Reader) string {
 	errorStruct := struct {
-		Result struct {
-			Data struct {
-				Error string
-			}
-		}
+		Error string
 	}{}
 
 	if err := json.NewDecoder(reader).Decode(&errorStruct); err != nil {
 		return ""
 	}
 
-	return errorStruct.Result.Data.Error
+	return errorStruct.Error
 }


### PR DESCRIPTION
We changed the response format on Cloud but forgot to make the change here. I've added putting some tests around this to my list of missing bigtest tests to make sure we don't break this again in the future.