### PR TITLE
Require authentication in mint run and mint debug

### DIFF
--- a/cmd/mint/debug.go
+++ b/cmd/mint/debug.go
@@ -8,6 +8,9 @@ import (
 
 var debugCmd = &cobra.Command{
 	Args: cobra.ExactArgs(1),
+	PreRunE: func(cmd *cobra.Command, args []string) error {
+		return requireAccessToken()
+	},
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return service.DebugTask(cli.DebugTaskConfig{RunURL: args[0]})
 	},

--- a/cmd/mint/require_access_token.go
+++ b/cmd/mint/require_access_token.go
@@ -1,0 +1,21 @@
+package main
+
+import (
+	"github.com/pkg/errors"
+	"github.com/rwx-research/mint-cli/internal/accesstoken"
+)
+
+func requireAccessToken() error {
+	token, err := accesstoken.Get(accessTokenBackend, AccessToken)
+	if err == nil && token != "" {
+		return nil
+	}
+
+	return errors.New(
+		"You're trying to use a command which requires authentication with RWX Cloud, " +
+			"but you do not have an access token configured.\n\n" +
+			"To use this command, you can authenticate with RWX Cloud via the `mint login` command, or " +
+			"you can supply the `--access-token` option or `RWX_ACCESS_TOKEN` environment variable.\n\n" +
+			"Once you do so, go ahead and run the command again.",
+	)
+}

--- a/cmd/mint/run.go
+++ b/cmd/mint/run.go
@@ -42,7 +42,7 @@ var (
 				}
 			}
 
-			return nil
+			return requireAccessToken()
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			var targetedTasks []string
@@ -87,7 +87,7 @@ var (
 
 		},
 		Short: "Start a new run on Mint",
-		Use:   "run [flags] --access-token=<token> [task]",
+		Use:   "run [flags] [task]",
 	}
 )
 


### PR DESCRIPTION
This addresses some discussion @TAGraves and I had around the help text/access token requirements.

```bash
$ ./mint run
Error: You're trying to use a command which requires authentication with RWX Cloud, but you do not have an access token configured.

To use this command, you can authenticate with RWX Cloud via the `mint login` command, or you can supply the `--access-token` option or `RWX_ACCESS_TOKEN` environment variable.

Once you do so, go ahead and run the command again.
$ ./mint debug 1
Error: You're trying to use a command which requires authentication with RWX Cloud, but you do not have an access token configured.

To use this command, you can authenticate with RWX Cloud via the `mint login` command, or you can supply the `--access-token` option or `RWX_ACCESS_TOKEN` environment variable.

Once you do so, go ahead and run the command again.
```