### PR TITLE
Use snake case in the initiate run endpoint, send structured init params

### DIFF
--- a/cmd/mint/run.go
+++ b/cmd/mint/run.go
@@ -68,10 +68,22 @@ var (
 			}
 
 			if Json {
-				runResultJson, err := json.Marshal(runResult)
+				jsonOutput := struct {
+					RunId            string
+					RunURL           string
+					TargetedTaskKeys []string
+					DefinitionPath   string
+				}{
+					RunId:            runResult.RunId,
+					RunURL:           runResult.RunURL,
+					TargetedTaskKeys: runResult.TargetedTaskKeys,
+					DefinitionPath:   runResult.DefinitionPath,
+				}
+				runResultJson, err := json.Marshal(jsonOutput)
 				if err != nil {
 					return err
 				}
+
 				fmt.Println(string(runResultJson))
 			} else {
 				fmt.Printf("Run is watchable at %s\n", runResult.RunURL)

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -92,7 +92,9 @@ func (c Client) InitiateRun(cfg InitiateRunConfig) (*InitiateRunResult, error) {
 		return nil, errors.Wrap(err, "validation failed")
 	}
 
-	encodedBody, err := json.Marshal(struct{ Run InitiateRunConfig }{cfg})
+	encodedBody, err := json.Marshal(struct {
+		Run InitiateRunConfig `json:"run"`
+	}{cfg})
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to encode as JSON")
 	}
@@ -120,22 +122,35 @@ func (c Client) InitiateRun(cfg InitiateRunConfig) (*InitiateRunResult, error) {
 	}
 
 	respBody := struct {
-		RunId            string
-		RunURL           string
-		TargetedTaskKeys []string
-		DefinitionPath   string
+		SnakeRunId            string   `json:"run_id"`
+		SnakeRunURL           string   `json:"run_url"`
+		SnakeTargetedTaskKeys []string `json:"targeted_task_keys"`
+		SnakeDefinitionPath   string   `json:"definition_path"`
+		CamelRunId            string   `json:"runId"`
+		CamelRunURL           string   `json:"runURL"`
+		CamelTargetedTaskKeys []string `json:"targetedTaskKeys"`
+		CamelDefinitionPath   string   `json:"definitionPath"`
 	}{}
 
 	if err := json.NewDecoder(resp.Body).Decode(&respBody); err != nil {
 		return nil, errors.Wrap(err, "unable to parse API response")
 	}
 
-	return &InitiateRunResult{
-		RunId:            respBody.RunId,
-		RunURL:           respBody.RunURL,
-		TargetedTaskKeys: respBody.TargetedTaskKeys,
-		DefinitionPath:   respBody.DefinitionPath,
-	}, nil
+	if respBody.CamelRunId != "" {
+		return &InitiateRunResult{
+			RunId:            respBody.CamelRunId,
+			RunURL:           respBody.CamelRunURL,
+			TargetedTaskKeys: respBody.CamelTargetedTaskKeys,
+			DefinitionPath:   respBody.CamelDefinitionPath,
+		}, nil
+	} else {
+		return &InitiateRunResult{
+			RunId:            respBody.SnakeRunId,
+			RunURL:           respBody.SnakeRunURL,
+			TargetedTaskKeys: respBody.SnakeTargetedTaskKeys,
+			DefinitionPath:   respBody.SnakeDefinitionPath,
+		}, nil
+	}
 }
 
 // ObtainAuthCode requests a new one-time-use code to login on a device

--- a/internal/api/config.go
+++ b/internal/api/config.go
@@ -20,10 +20,15 @@ func (c Config) Validate() error {
 }
 
 type InitiateRunConfig struct {
-	InitializationParameters map[string]string
-	TaskDefinitions          []TaskDefinition
-	TargetedTaskKeys         []string `json:",omitempty"`
-	UseCache                 bool
+	InitializationParameters []InitializationParameter `json:"initialization_parameters"`
+	TaskDefinitions          []TaskDefinition          `json:"task_definitions"`
+	TargetedTaskKeys         []string                  `json:"targeted_task_keys,omitempty"`
+	UseCache                 bool                      `json:"use_cache"`
+}
+
+type InitializationParameter struct {
+	Key   string `json:"key"`
+	Value string `json:"value"`
 }
 
 type InitiateRunResult struct {

--- a/internal/api/task_definition.go
+++ b/internal/api/task_definition.go
@@ -1,6 +1,6 @@
 package api
 
 type TaskDefinition struct {
-	Path         string
-	FileContents string // This type is expected by cloud
+	Path         string `json:"path"`
+	FileContents string `json:"file_contents"` // This type is expected by cloud
 }

--- a/internal/cli/service.go
+++ b/internal/cli/service.go
@@ -133,8 +133,18 @@ func (s Service) InitiateRun(cfg InitiateRunConfig) (*api.InitiateRunResult, err
 		}
 	}
 
+	i := 0
+	initializationParameters := make([]api.InitializationParameter, len(cfg.InitParameters))
+	for key, value := range cfg.InitParameters {
+		initializationParameters[i] = api.InitializationParameter{
+			Key:   key,
+			Value: value,
+		}
+		i++
+	}
+
 	runResult, err := s.APIClient.InitiateRun(api.InitiateRunConfig{
-		InitializationParameters: cfg.InitParameters,
+		InitializationParameters: initializationParameters,
 		TaskDefinitions:          taskDefinitions,
 		TargetedTaskKeys:         cfg.TargetedTasks,
 		UseCache:                 !cfg.NoCache,


### PR DESCRIPTION
Updates the `InitiateRun` client function to send snake case and structured init params. It also updates it to accept snake case or camelcase responses from the endpoint so we can transition that to snake case as well.