### PR TITLE
Adds mint vaults set-secrets

### DIFF
--- a/cmd/mint/root.go
+++ b/cmd/mint/root.go
@@ -69,4 +69,5 @@ func init() {
 	rootCmd.AddCommand(debugCmd)
 	rootCmd.AddCommand(loginCmd)
 	rootCmd.AddCommand(whoamiCmd)
+	rootCmd.AddCommand(vaultsCmd)
 }

--- a/cmd/mint/vaults.go
+++ b/cmd/mint/vaults.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"os"
+
+	"github.com/rwx-research/mint-cli/internal/cli"
+	"github.com/spf13/cobra"
+)
+
+var vaultsCmd = &cobra.Command{
+ 	Short: "Manage Mint vaults and secrets",
+	Use:   "vaults",
+}
+
+var (
+	Vault string
+	File    string
+
+	vaultsSetSecretsCmd = &cobra.Command{
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			return requireAccessToken()
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			var secrets []string
+			if len(args) >= 0 {
+				secrets = args
+			}
+
+			return service.SetSecretsInVault(cli.SetSecretsInVaultConfig{
+				Vault: Vault,
+				File: File,
+				Secrets: secrets,
+				Stdout: os.Stdout,
+			})
+		},
+		Short: "Set secrets in a vault",
+		Use:   "set-secrets [flags] [SECRETNAME=secretvalue]",
+	}
+)
+
+func init() {
+	vaultsSetSecretsCmd.Flags().StringVar(&Vault, "vault", "default", "the name of the vault to set the secrets in")
+	vaultsSetSecretsCmd.Flags().StringVar(&File, "file", "", "the path to a file in dotenv format to read the secrets from")
+	vaultsCmd.AddCommand(vaultsSetSecretsCmd);
+}

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -246,6 +246,44 @@ func (c Client) Whoami() (*WhoamiResult, error) {
 	return &respBody, nil
 }
 
+func (c Client) SetSecretsInVault(cfg SetSecretsInVaultConfig) (*SetSecretsInVaultResult, error) {
+	endpoint := "/mint/api/vaults/secrets"
+
+	encodedBody, err := json.Marshal(cfg)
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to encode as JSON")
+	}
+
+	req, err := http.NewRequest(http.MethodPost, endpoint, bytes.NewBuffer(encodedBody))
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to create new HTTP request")
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := c.RoundTrip(req)
+	if err != nil {
+		return nil, errors.Wrap(err, "HTTP request failed")
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 200 {
+		msg := extractErrorMessage(resp.Body)
+		if msg == "" {
+			msg = fmt.Sprintf("Unable to call Mint API - %s", resp.Status)
+		}
+
+		return nil, errors.New(msg)
+	}
+
+	respBody := SetSecretsInVaultResult{}
+	if err := json.NewDecoder(resp.Body).Decode(&respBody); err != nil {
+		return nil, errors.Wrap(err, "unable to parse API response")
+	}
+
+	return &respBody, nil
+}
+
 // extractErrorMessage is a small helper function for parsing an API error message
 func extractErrorMessage(reader io.Reader) string {
 	errorStruct := struct {

--- a/internal/api/client_test.go
+++ b/internal/api/client_test.go
@@ -186,4 +186,28 @@ var _ = Describe("API Client", func() {
 			Expect(err).To(BeNil())
 		})
 	})
+
+	Describe("SetSecretsInVault", func() {
+		It("makes the request", func() {
+			body := api.SetSecretsInVaultConfig{
+				VaultName: "default",
+				Secrets: []api.Secret{{Name: "ABC", Secret: "123"}},
+			}
+			bodyBytes, _ := json.Marshal(body)
+
+			roundTrip := func(req *http.Request) (*http.Response, error) {
+				Expect(req.URL.Path).To(Equal("/mint/api/vaults/secrets"))
+				return &http.Response{
+					Status:     "200 OK",
+					StatusCode: 200,
+					Body:       io.NopCloser(bytes.NewReader(bodyBytes)),
+				}, nil
+			}
+
+			c := api.Client{roundTrip}
+
+			_, err := c.SetSecretsInVault(body)
+			Expect(err).To(BeNil())
+		})
+	})
 })

--- a/internal/api/config.go
+++ b/internal/api/config.go
@@ -77,3 +77,17 @@ type WhoamiResult struct {
 	TokenKind        string  `json:"token_kind"` // organization_access_token, personal_access_token
 	UserEmail        *string `json:"user_email,omitempty"`
 }
+
+type SetSecretsInVaultConfig struct {
+	Secrets   []Secret `json:"secrets"`
+	VaultName string  `json:"vault_name"`
+}
+
+type Secret struct {
+	Name   string `json:"name"`
+	Secret string `json:"secret"`
+}
+
+type SetSecretsInVaultResult struct {
+	SetSecrets []string `json:"set_secrets"`
+}

--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -82,3 +82,23 @@ type WhoamiConfig struct {
 func (c WhoamiConfig) Validate() error {
 	return nil
 }
+
+type SetSecretsInVaultConfig struct {
+	Secrets []string
+	Vault   string
+	File    string
+	Stdout  io.Writer
+}
+
+func (c SetSecretsInVaultConfig) Validate() error {
+	if c.Vault == "" {
+		return errors.New("the vault name must be provided")
+	}
+
+	if len(c.Secrets) == 0 && c.File == "" {
+		return errors.New("the secrets to set must be provided")
+	}
+
+	return nil
+}
+

--- a/internal/cli/interfaces.go
+++ b/internal/cli/interfaces.go
@@ -12,6 +12,7 @@ type APIClient interface {
 	ObtainAuthCode(api.ObtainAuthCodeConfig) (*api.ObtainAuthCodeResult, error)
 	AcquireToken(tokenUrl string) (*api.AcquireTokenResult, error)
 	Whoami() (*api.WhoamiResult, error)
+	SetSecretsInVault(api.SetSecretsInVaultConfig) (*api.SetSecretsInVaultResult, error)
 }
 
 type SSHClient interface {

--- a/internal/mocks/api.go
+++ b/internal/mocks/api.go
@@ -11,6 +11,7 @@ type API struct {
 	MockObtainAuthCode         func(api.ObtainAuthCodeConfig) (*api.ObtainAuthCodeResult, error)
 	MockAcquireToken           func(tokenUrl string) (*api.AcquireTokenResult, error)
 	MockWhoami                 func() (*api.WhoamiResult, error)
+	MockSetSecretsInVault      func(api.SetSecretsInVaultConfig) (*api.SetSecretsInVaultResult, error)
 }
 
 func (c *API) InitiateRun(cfg api.InitiateRunConfig) (*api.InitiateRunResult, error) {
@@ -52,3 +53,12 @@ func (c *API) Whoami() (*api.WhoamiResult, error) {
 
 	return nil, errors.New("MockWhoami was not configured")
 }
+
+func (c *API) SetSecretsInVault(cfg api.SetSecretsInVaultConfig) (*api.SetSecretsInVaultResult, error) {
+	if c.MockSetSecretsInVault != nil {
+		return c.MockSetSecretsInVault(cfg)
+	}
+
+	return nil, errors.New("MockSetSecretsInVault was not configured")
+}
+


### PR DESCRIPTION
This adds a new command which can be used to set secrets programmatically.

The command is used like so:
```
mint vaults set-secrets --vault default ABC=123 DEF=xyz
```

Or, you can pass the secrets in via a file in the dotenv format:
```
mint vaults set-secrets --vault default --file secrets.txt
```