### PR TITLE
Improve error message when debug session is cancelled

### DIFF
--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -12,6 +12,7 @@ var (
 	ErrNotFound      = errors.New("not found")
 	ErrGone          = errors.New("gone")
 
+	As        = errors.As
 	Errorf    = errors.Errorf
 	Is        = errors.Is
 	New       = errors.New


### PR DESCRIPTION
We've previously returned a somewhat cryptic error message if the ssh session was closed by the agent. This is the case if a task or run is cancelled, for example.