### PR TITLE
Adds a flag to specify a title

### DIFF
--- a/cmd/mint/run.go
+++ b/cmd/mint/run.go
@@ -22,6 +22,7 @@ var (
 	MintFilePath   string
 	NoCache        bool
 	Open           bool
+	Title					 string
 
 	runCmd = &cobra.Command{
 		PreRunE: func(cmd *cobra.Command, args []string) error {
@@ -62,6 +63,7 @@ var (
 				MintFilePath:   MintFilePath,
 				NoCache:        NoCache,
 				TargetedTasks:  targetedTasks,
+				Title:					Title,
 			})
 			if err != nil {
 				return err
@@ -109,6 +111,7 @@ func init() {
 	runCmd.Flags().StringVarP(&MintFilePath, "file", "f", "", "a Mint config file to use for sourcing task definitions")
 	runCmd.Flags().StringVar(&MintDirectory, "dir", ".mint", "the directory containing your mint task definitions. By default, this is used to source task definitions")
 	runCmd.Flags().BoolVar(&Open, "open", false, "open the run in a browser")
+	runCmd.Flags().StringVar(&Title, "title", "", "the title the UI will display for the Mint run")
 	runCmd.Flags().BoolVar(&Json, "json", false, "output json data to stdout")
 }
 

--- a/internal/api/config.go
+++ b/internal/api/config.go
@@ -23,6 +23,7 @@ type InitiateRunConfig struct {
 	InitializationParameters []InitializationParameter `json:"initialization_parameters"`
 	TaskDefinitions          []TaskDefinition          `json:"task_definitions"`
 	TargetedTaskKeys         []string                  `json:"targeted_task_keys,omitempty"`
+	Title                    string                    `json:"title,omitempty"`
 	UseCache                 bool                      `json:"use_cache"`
 }
 

--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -49,6 +49,7 @@ type InitiateRunConfig struct {
 	MintFilePath   string
 	NoCache        bool
 	TargetedTasks  []string
+	Title          string
 }
 
 func (c InitiateRunConfig) Validate() error {

--- a/internal/cli/service.go
+++ b/internal/cli/service.go
@@ -155,6 +155,7 @@ func (s Service) InitiateRun(cfg InitiateRunConfig) (*api.InitiateRunResult, err
 		InitializationParameters: initializationParameters,
 		TaskDefinitions:          taskDefinitions,
 		TargetedTaskKeys:         cfg.TargetedTasks,
+		Title:                    cfg.Title,
 		UseCache:                 !cfg.NoCache,
 	})
 	if err != nil {


### PR DESCRIPTION
When initiating a run from the CLI, you'll now be able to specify a title which will be used when displaying the run in the Mint CLI.