### PR TITLE
Configure a tool cache vault for bigtest

### DIFF
--- a/.mint/bigtest.yml
+++ b/.mint/bigtest.yml
@@ -13,6 +13,9 @@ concurrency-pools:
     capacity: 1
     on-overflow: cancel-running
 
+tool-cache:
+  vault: mint_cli_main
+
 tasks:
   - key: clone
     call: mint/git-clone 1.1.4


### PR DESCRIPTION
This is required for bigtest to be able to run.