### PR TITLE
Improve the behavior of --dir and --file

### DIFF
--- a/cmd/mint/run.go
+++ b/cmd/mint/run.go
@@ -109,7 +109,7 @@ func init() {
 	runCmd.Flags().BoolVar(&NoCache, "no-cache", false, "do not read or write to the cache")
 	runCmd.Flags().StringArrayVar(&InitParameters, flagInit, []string{}, "initialization parameters for the run, available in the `init` context. Can be specified multiple times")
 	runCmd.Flags().StringVarP(&MintFilePath, "file", "f", "", "a Mint config file to use for sourcing task definitions")
-	runCmd.Flags().StringVar(&MintDirectory, "dir", ".mint", "the directory containing your mint task definitions. By default, this is used to source task definitions")
+	runCmd.Flags().StringVarP(&MintDirectory, "dir", "d", "", "the directory your Mint files are located in, typicalling `.mint`. By default, the CLI traverses up until it finds a `.mint` directory.")
 	runCmd.Flags().BoolVar(&Open, "open", false, "open the run in a browser")
 	runCmd.Flags().StringVar(&Title, "title", "", "the title the UI will display for the Mint run")
 	runCmd.Flags().BoolVar(&Json, "json", false, "output json data to stdout")

--- a/internal/api/config.go
+++ b/internal/api/config.go
@@ -22,6 +22,7 @@ func (c Config) Validate() error {
 type InitiateRunConfig struct {
 	InitializationParameters []InitializationParameter `json:"initialization_parameters"`
 	TaskDefinitions          []TaskDefinition          `json:"task_definitions"`
+	MintDirectory            []TaskDefinition          `json:"mint_directory,omitempty"`
 	TargetedTaskKeys         []string                  `json:"targeted_task_keys,omitempty"`
 	Title                    string                    `json:"title,omitempty"`
 	UseCache                 bool                      `json:"use_cache"`

--- a/internal/api/config.go
+++ b/internal/api/config.go
@@ -22,7 +22,7 @@ func (c Config) Validate() error {
 type InitiateRunConfig struct {
 	InitializationParameters []InitializationParameter `json:"initialization_parameters"`
 	TaskDefinitions          []TaskDefinition          `json:"task_definitions"`
-	MintDirectory            []TaskDefinition          `json:"mint_directory,omitempty"`
+	MintDirectory            []TaskDefinition          `json:"mint_directory"`
 	TargetedTaskKeys         []string                  `json:"targeted_task_keys,omitempty"`
 	Title                    string                    `json:"title,omitempty"`
 	UseCache                 bool                      `json:"use_cache"`

--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -53,10 +53,6 @@ type InitiateRunConfig struct {
 }
 
 func (c InitiateRunConfig) Validate() error {
-	if c.MintDirectory == "" && c.MintFilePath == "" {
-		return errors.New("either the mint directory or the mint config file path needs to be set")
-	}
-
 	return nil
 }
 
@@ -102,4 +98,3 @@ func (c SetSecretsInVaultConfig) Validate() error {
 
 	return nil
 }
-

--- a/internal/cli/service.go
+++ b/internal/cli/service.go
@@ -106,7 +106,7 @@ func (s Service) InitiateRun(cfg InitiateRunConfig) (*api.InitiateRunResult, err
 		return nil, errors.Wrap(err, "validation failed")
 	}
 
-	var mintDirectoryYamlPaths []string
+	mintDirectoryYamlPaths := make([]string, 0)
 	taskDefinitionYamlPaths := make([]string, 0)
 
 	mintDirectoryPath, err := s.findMintDirectoryPath(cfg.MintDirectory)
@@ -131,7 +131,6 @@ func (s Service) InitiateRun(cfg InitiateRunConfig) (*api.InitiateRunResult, err
 	// (whether it was specified or found via traversal)
 	if cfg.MintFilePath == "" {
 		taskDefinitionYamlPaths = mintDirectoryYamlPaths
-		mintDirectoryYamlPaths = nil
 	} else {
 		taskDefinitionYamlPaths = append(taskDefinitionYamlPaths, cfg.MintFilePath)
 	}
@@ -144,14 +143,11 @@ func (s Service) InitiateRun(cfg InitiateRunConfig) (*api.InitiateRunResult, err
 		}
 	}
 
-	var mintDirectory []api.TaskDefinition
-	if mintDirectoryYamlPaths != nil {
-		taskDefinitionsInMintDirectory, err := s.taskDefinitionsFromPaths(mintDirectoryYamlPaths)
-		if err != nil {
-			return nil, errors.Wrap(err, "unable to read provided files")
-		}
-		mintDirectory = taskDefinitionsInMintDirectory
+	mintDirectory, err := s.taskDefinitionsFromPaths(mintDirectoryYamlPaths)
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to read provided files")
 	}
+
 	taskDefinitions, err := s.taskDefinitionsFromPaths(taskDefinitionYamlPaths)
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to read provided files")

--- a/internal/cli/service_test.go
+++ b/internal/cli/service_test.go
@@ -292,7 +292,7 @@ var _ = Describe("CLI Service", func() {
 					mockAPI.MockInitiateRun = func(cfg api.InitiateRunConfig) (*api.InitiateRunResult, error) {
 						Expect(cfg.TaskDefinitions).To(HaveLen(1))
 						Expect(cfg.TaskDefinitions[0].Path).To(Equal(runConfig.MintFilePath))
-						Expect(cfg.MintDirectory).To(BeNil())
+						Expect(cfg.MintDirectory).To(HaveLen(0))
 						Expect(cfg.UseCache).To(BeTrue())
 						receivedSpecifiedFileContent = cfg.TaskDefinitions[0].FileContents
 						return &api.InitiateRunResult{
@@ -318,10 +318,12 @@ var _ = Describe("CLI Service", func() {
 		Context("with no specific mint file and no specific directory", func() {
 			Context("when a directory with files is found", func() {
 				var originalMintDirFileContent string
+				var receivedTaskDefinitionsFileContent string
 				var receivedMintDirFileContent string
 
 				BeforeEach(func() {
 					originalMintDirFileContent = "tasks:\n  - key: mintdir\n    run: echo 'mintdir'\n"
+					receivedTaskDefinitionsFileContent = ""
 					receivedMintDirFileContent = ""
 					runConfig.MintFilePath = ""
 					runConfig.MintDirectory = ""
@@ -350,11 +352,13 @@ var _ = Describe("CLI Service", func() {
 					}
 					mockAPI.MockInitiateRun = func(cfg api.InitiateRunConfig) (*api.InitiateRunResult, error) {
 						Expect(cfg.TaskDefinitions).To(HaveLen(1))
-						// note that this is relative to cwd and that the mint dir files are in task definitions instead of mint directory
+						// note that this is relative to cwd
 						Expect(cfg.TaskDefinitions[0].Path).To(Equal("../../.mint/mintdir-tasks.yml"))
-						Expect(cfg.MintDirectory).To(BeNil())
+						Expect(cfg.MintDirectory).To(HaveLen(1))
+						Expect(cfg.MintDirectory[0].Path).To(Equal(".mint/mintdir-tasks.yml"))
 						Expect(cfg.UseCache).To(BeTrue())
-						receivedMintDirFileContent = cfg.TaskDefinitions[0].FileContents
+						receivedTaskDefinitionsFileContent = cfg.TaskDefinitions[0].FileContents
+						receivedMintDirFileContent = cfg.MintDirectory[0].FileContents
 						return &api.InitiateRunResult{
 							RunId:            "785ce4e8-17b9-4c8b-8869-a55e95adffe7",
 							RunURL:           "https://cloud.rwx.com/mint/rwx/runs/785ce4e8-17b9-4c8b-8869-a55e95adffe7",
@@ -370,6 +374,7 @@ var _ = Describe("CLI Service", func() {
 				})
 
 				It("sends the file contents to cloud", func() {
+					Expect(receivedTaskDefinitionsFileContent).To(Equal(originalMintDirFileContent))
 					Expect(receivedMintDirFileContent).To(Equal(originalMintDirFileContent))
 				})
 			})
@@ -678,10 +683,12 @@ var _ = Describe("CLI Service", func() {
 		Context("with no specific mint file and a specific directory", func() {
 			Context("when a directory with files is found", func() {
 				var originalMintDirFileContent string
+				var receivedTaskDefinitionsFileContent string
 				var receivedMintDirFileContent string
 
 				BeforeEach(func() {
 					originalMintDirFileContent = "tasks:\n  - key: mintdir\n    run: echo 'mintdir'\n"
+					receivedTaskDefinitionsFileContent = ""
 					receivedMintDirFileContent = ""
 					runConfig.MintFilePath = ""
 					runConfig.MintDirectory = "some-dir"
@@ -706,9 +713,11 @@ var _ = Describe("CLI Service", func() {
 						Expect(cfg.TaskDefinitions).To(HaveLen(1))
 						// note that this is the _specified_ dir and path to the file
 						Expect(cfg.TaskDefinitions[0].Path).To(Equal("some-dir/mintdir-tasks.yml"))
-						Expect(cfg.MintDirectory).To(BeNil())
+						Expect(cfg.MintDirectory).To(HaveLen(1))
+						Expect(cfg.MintDirectory[0].Path).To(Equal(".mint/mintdir-tasks.yml"))
 						Expect(cfg.UseCache).To(BeTrue())
-						receivedMintDirFileContent = cfg.TaskDefinitions[0].FileContents
+						receivedTaskDefinitionsFileContent = cfg.TaskDefinitions[0].FileContents
+						receivedMintDirFileContent = cfg.MintDirectory[0].FileContents
 						return &api.InitiateRunResult{
 							RunId:            "785ce4e8-17b9-4c8b-8869-a55e95adffe7",
 							RunURL:           "https://cloud.rwx.com/mint/rwx/runs/785ce4e8-17b9-4c8b-8869-a55e95adffe7",
@@ -724,6 +733,7 @@ var _ = Describe("CLI Service", func() {
 				})
 
 				It("sends the file contents to cloud", func() {
+					Expect(receivedTaskDefinitionsFileContent).To(Equal(originalMintDirFileContent))
 					Expect(receivedMintDirFileContent).To(Equal(originalMintDirFileContent))
 				})
 			})

--- a/internal/cli/service_test.go
+++ b/internal/cli/service_test.go
@@ -1,6 +1,7 @@
 package cli_test
 
 import (
+	"os"
 	"sort"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -53,171 +54,60 @@ var _ = Describe("CLI Service", func() {
 			runConfig = cli.InitiateRunConfig{}
 		})
 
-		Context("with a specific mint config file", func() {
-			var originalFileContent string
-			var receivedFileContent string
+		Context("with a specific mint file and no specific directory", func() {
+			Context("when a directory with files is found", func() {
+				var originalSpecifiedFileContent string
+				var originalMintDirFileContent string
+				var receivedSpecifiedFileContent string
+				var receivedMintDirFileContent string
 
-			BeforeEach(func() {
-				originalFileContent = "tasks:\n  - key: foo\n    run: echo 'bar'\n"
-				receivedFileContent = ""
-				runConfig.MintFilePath = "mint.yml"
-
-				mockFS.MockOpen = func(name string) (fs.File, error) {
-					Expect(name).To(Equal("mint.yml"))
-					file := mocks.NewFile(originalFileContent)
-					return file, nil
-				}
-				mockAPI.MockInitiateRun = func(cfg api.InitiateRunConfig) (*api.InitiateRunResult, error) {
-					Expect(cfg.TaskDefinitions).To(HaveLen(1))
-					Expect(cfg.TaskDefinitions[0].Path).To(Equal(runConfig.MintFilePath))
-					Expect(cfg.UseCache).To(BeTrue())
-					receivedFileContent = cfg.TaskDefinitions[0].FileContents
-					return &api.InitiateRunResult{
-						RunId:            "785ce4e8-17b9-4c8b-8869-a55e95adffe7",
-						RunURL:           "https://cloud.rwx.com/mint/rwx/runs/785ce4e8-17b9-4c8b-8869-a55e95adffe7",
-						TargetedTaskKeys: []string{},
-						DefinitionPath:   ".mint/mint.yml",
-					}, nil
-				}
-			})
-
-			JustBeforeEach(func() {
-				_, err := service.InitiateRun(runConfig)
-				Expect(err).ToNot(HaveOccurred())
-			})
-
-			It("sends the file contents to cloud", func() {
-				Expect(receivedFileContent).To(Equal(originalFileContent))
-			})
-
-			Context("and the `--no-cache` flag", func() {
 				BeforeEach(func() {
-					runConfig.NoCache = true
+					originalSpecifiedFileContent = "tasks:\n  - key: foo\n    run: echo 'bar'\n"
+					originalMintDirFileContent = "tasks:\n  - key: mintdir\n    run: echo 'mintdir'\n"
+					receivedSpecifiedFileContent = ""
+					receivedMintDirFileContent = ""
+					runConfig.MintFilePath = "mint.yml"
+					runConfig.MintDirectory = ""
 
-					mockAPI.MockInitiateRun = func(cfg api.InitiateRunConfig) (*api.InitiateRunResult, error) {
-						Expect(cfg.TaskDefinitions).To(HaveLen(1))
-						Expect(cfg.TaskDefinitions[0].Path).To(Equal(runConfig.MintFilePath))
-						Expect(cfg.UseCache).To(BeFalse())
-						receivedFileContent = cfg.TaskDefinitions[0].FileContents
-						return &api.InitiateRunResult{
-							RunId:            "785ce4e8-17b9-4c8b-8869-a55e95adffe7",
-							RunURL:           "https://cloud.rwx.com/mint/rwx/runs/785ce4e8-17b9-4c8b-8869-a55e95adffe7",
-							TargetedTaskKeys: []string{},
-							DefinitionPath:   ".mint/mint.yml",
+					mockFS.MockGetwd = func() (string, error) {
+						return "/some/path/to/working/directory", nil
+					}
+					mockFS.MockExists = func(name string) (bool, error) {
+						return name == "/some/path/to/.mint", nil
+					}
+					mockFS.MockReadDir = func(name string) ([]fs.DirEntry, error) {
+						Expect(name).To(Equal("/some/path/to/.mint"))
+						return []fs.DirEntry{
+							mocks.DirEntry{FileName: "mintdir-tasks.yml"},
+							mocks.DirEntry{FileName: "mintdir-tasks.json"},
 						}, nil
 					}
-				})
-
-				It("instructs the API client to not use the cache", func() {})
-			})
-
-			Context("and an optional task key argument", func() {
-				BeforeEach(func() {
-					runConfig.TargetedTasks = []string{fmt.Sprintf("%d", GinkgoRandomSeed())}
-
-					mockAPI.MockInitiateRun = func(cfg api.InitiateRunConfig) (*api.InitiateRunResult, error) {
-						Expect(cfg.TaskDefinitions).To(HaveLen(1))
-						Expect(cfg.TaskDefinitions[0].Path).To(Equal(runConfig.MintFilePath))
-						Expect(cfg.TargetedTaskKeys).To(Equal([]string{fmt.Sprintf("%d", GinkgoRandomSeed())}))
-						receivedFileContent = cfg.TaskDefinitions[0].FileContents
-						return &api.InitiateRunResult{
-							RunId:            "785ce4e8-17b9-4c8b-8869-a55e95adffe7",
-							RunURL:           "https://cloud.rwx.com/mint/rwx/runs/785ce4e8-17b9-4c8b-8869-a55e95adffe7",
-							TargetedTaskKeys: []string{},
-							DefinitionPath:   ".mint/mint.yml",
-						}, nil
-					}
-				})
-
-				It("instructs the API client to target the specified task key", func() {})
-			})
-		})
-
-		Context("with a specific mint directory", func() {
-			BeforeEach(func() {
-				runConfig.MintDirectory = "test"
-			})
-
-			Context("which is empty", func() {
-				var err error
-
-				BeforeEach(func() {
-					err = nil
-					mockFS.MockReadDir = func(name string) ([]fs.DirEntry, error) {
-						return []fs.DirEntry{}, nil
-					}
-				})
-
-				JustBeforeEach(func() {
-					_, err = service.InitiateRun(runConfig)
-				})
-
-				It("returns an error", func() {
-					Expect(err).To(HaveOccurred())
-					Expect(err.Error()).To(ContainSubstring("No run definitions provided"))
-				})
-			})
-
-			Context("which contains an invalid yaml file", func() {
-				var originalFileContent string
-				var err error
-
-				BeforeEach(func() {
-					err = nil
-					originalFileContent = "tasks:\n  - key:\n      run: - echo 'bar'\n"
-
-					mockFS.MockReadDir = func(name string) ([]fs.DirEntry, error) {
-						file := mocks.DirEntry{FileName: "mint.yaml"}
-						return []fs.DirEntry{file}, nil
-					}
-					mockFS.MockOpen = func(path string) (fs.File, error) {
-						file := mocks.NewFile(originalFileContent)
-						return file, nil
-					}
-				})
-
-				JustBeforeEach(func() {
-					_, err = service.InitiateRun(runConfig)
-				})
-
-				It("returns an error", func() {
-					Expect(err).To(HaveOccurred())
-					Expect(err.Error()).To(ContainSubstring("unable to parse"))
-				})
-			})
-
-			Context("which contains a mixture of files", func() {
-				var originalFileContents map[string]string
-				var receivedFileContents map[string]string
-
-				BeforeEach(func() {
-					receivedFileContents = make(map[string]string)
-					originalFileContents = make(map[string]string)
-					originalFileContents["test/foobar.yaml"] = "tasks:\n  - key: foo\n    run: echo 'bar'\n"
-					originalFileContents["test/onetwo.yml"] = "tasks:\n  - key: one\n    run: echo 'two'\n"
-					originalFileContents["test/helloworld.json"] = "tasks:\n  - key: hello\n    run: echo 'world'\n"
-
-					mockAPI.MockInitiateRun = func(cfg api.InitiateRunConfig) (*api.InitiateRunResult, error) {
-						for _, def := range cfg.TaskDefinitions {
-							receivedFileContents[def.Path] = def.FileContents
+					mockFS.MockOpen = func(name string) (fs.File, error) {
+						if name == "mint.yml" {
+							file := mocks.NewFile(originalSpecifiedFileContent)
+							return file, nil
+						} else if name == "/some/path/to/.mint/mintdir-tasks.yml" {
+							file := mocks.NewFile(originalMintDirFileContent)
+							return file, nil
+						} else {
+							Expect(name).To(BeNil())
+							return nil, errors.New("file does not exist")
 						}
+					}
+					mockAPI.MockInitiateRun = func(cfg api.InitiateRunConfig) (*api.InitiateRunResult, error) {
+						Expect(cfg.TaskDefinitions).To(HaveLen(1))
+						Expect(cfg.TaskDefinitions[0].Path).To(Equal(runConfig.MintFilePath))
+						Expect(cfg.MintDirectory).To(HaveLen(1))
+						Expect(cfg.MintDirectory[0].Path).To(Equal(".mint/mintdir-tasks.yml"))
+						Expect(cfg.UseCache).To(BeTrue())
+						receivedSpecifiedFileContent = cfg.TaskDefinitions[0].FileContents
+						receivedMintDirFileContent = cfg.MintDirectory[0].FileContents
 						return &api.InitiateRunResult{
 							RunId:            "785ce4e8-17b9-4c8b-8869-a55e95adffe7",
 							RunURL:           "https://cloud.rwx.com/mint/rwx/runs/785ce4e8-17b9-4c8b-8869-a55e95adffe7",
 							TargetedTaskKeys: []string{},
 							DefinitionPath:   ".mint/mint.yml",
 						}, nil
-					}
-					mockFS.MockReadDir = func(name string) ([]fs.DirEntry, error) {
-						foobar := mocks.DirEntry{FileName: "foobar.yaml"}
-						onetwo := mocks.DirEntry{FileName: "onetwo.yml"}
-						subdir := mocks.DirEntry{FileName: "directory.yaml", IsDirectory: true}
-						return []fs.DirEntry{foobar, onetwo, subdir}, nil
-					}
-					mockFS.MockOpen = func(path string) (fs.File, error) {
-						Expect(originalFileContents).To(HaveKey(path))
-						file := mocks.NewFile(originalFileContents[path])
-						return file, nil
 					}
 				})
 
@@ -226,16 +116,683 @@ var _ = Describe("CLI Service", func() {
 					Expect(err).ToNot(HaveOccurred())
 				})
 
-				It("sends the file contents of *.yml and *.yaml files", func() {
-					for path, content := range originalFileContents {
-						if strings.HasSuffix(path, ".yml") || strings.HasSuffix(path, ".yaml") {
-							Expect(receivedFileContents[path]).To(Equal(content))
+				It("sends the file contents to cloud", func() {
+					Expect(receivedSpecifiedFileContent).To(Equal(originalSpecifiedFileContent))
+					Expect(receivedMintDirFileContent).To(Equal(originalMintDirFileContent))
+				})
+			})
+
+			Context("when the specified file is invalid", func() {
+				var originalSpecifiedFileContent string
+				var originalMintDirFileContent string
+
+				BeforeEach(func() {
+					originalSpecifiedFileContent = "NOT YAML!!!"
+					originalMintDirFileContent = "tasks:\n  - key: mintdir\n    run: echo 'mintdir'\n"
+					runConfig.MintFilePath = "mint.yml"
+					runConfig.MintDirectory = ""
+
+					mockFS.MockGetwd = func() (string, error) {
+						return "/some/path/to/working/directory", nil
+					}
+					mockFS.MockExists = func(name string) (bool, error) {
+						return name == "/some/path/to/.mint", nil
+					}
+					mockFS.MockReadDir = func(name string) ([]fs.DirEntry, error) {
+						Expect(name).To(Equal("/some/path/to/.mint"))
+						return []fs.DirEntry{
+							mocks.DirEntry{FileName: "mintdir-tasks.yml"},
+							mocks.DirEntry{FileName: "mintdir-tasks.json"},
+						}, nil
+					}
+					mockFS.MockOpen = func(name string) (fs.File, error) {
+						if name == "mint.yml" {
+							file := mocks.NewFile(originalSpecifiedFileContent)
+							return file, nil
+						} else if name == "/some/path/to/.mint/mintdir-tasks.yml" {
+							file := mocks.NewFile(originalMintDirFileContent)
+							return file, nil
+						} else {
+							Expect(name).To(BeNil())
+							return nil, errors.New("file does not exist")
 						}
 					}
 				})
 
-				It("doesn't send yaml files from sub-directories", func() {
-					Expect(receivedFileContents).ToNot(HaveKey("test/directory.yaml"))
+				It("returns an error", func() {
+					_, err := service.InitiateRun(runConfig)
+					Expect(err).To(HaveOccurred())
+					Expect(err.Error()).To(ContainSubstring("unable to parse"))
+				})
+			})
+
+			Context("when a directory with invalid files is found", func() {
+				var originalSpecifiedFileContent string
+				var originalMintDirFileContent string
+
+				BeforeEach(func() {
+					originalSpecifiedFileContent = "tasks:\n  - key: foo\n    run: echo 'bar'\n"
+					originalMintDirFileContent = "NOT YAML!!!!!!!!"
+					runConfig.MintFilePath = "mint.yml"
+					runConfig.MintDirectory = ""
+
+					mockFS.MockGetwd = func() (string, error) {
+						return "/some/path/to/working/directory", nil
+					}
+					mockFS.MockExists = func(name string) (bool, error) {
+						return name == "/some/path/to/.mint", nil
+					}
+					mockFS.MockReadDir = func(name string) ([]fs.DirEntry, error) {
+						Expect(name).To(Equal("/some/path/to/.mint"))
+						return []fs.DirEntry{
+							mocks.DirEntry{FileName: "mintdir-tasks.yml"},
+							mocks.DirEntry{FileName: "mintdir-tasks.json"},
+						}, nil
+					}
+					mockFS.MockOpen = func(name string) (fs.File, error) {
+						if name == "mint.yml" {
+							file := mocks.NewFile(originalSpecifiedFileContent)
+							return file, nil
+						} else if name == "/some/path/to/.mint/mintdir-tasks.yml" {
+							file := mocks.NewFile(originalMintDirFileContent)
+							return file, nil
+						} else {
+							Expect(name).To(BeNil())
+							return nil, errors.New("file does not exist")
+						}
+					}
+				})
+
+				It("returns an error", func() {
+					_, err := service.InitiateRun(runConfig)
+					Expect(err).To(HaveOccurred())
+					Expect(err.Error()).To(ContainSubstring("unable to parse"))
+				})
+			})
+
+			Context("when an empty directory is found", func() {
+				var originalSpecifiedFileContent string
+				var receivedSpecifiedFileContent string
+
+				BeforeEach(func() {
+					originalSpecifiedFileContent = "tasks:\n  - key: foo\n    run: echo 'bar'\n"
+					receivedSpecifiedFileContent = ""
+					runConfig.MintFilePath = "mint.yml"
+					runConfig.MintDirectory = ""
+
+					mockFS.MockGetwd = func() (string, error) {
+						return "/some/path/to/working/directory", nil
+					}
+					mockFS.MockExists = func(name string) (bool, error) {
+						return name == "/some/path/to/.mint", nil
+					}
+					mockFS.MockReadDir = func(name string) ([]fs.DirEntry, error) {
+						Expect(name).To(Equal("/some/path/to/.mint"))
+						return []fs.DirEntry{}, nil
+					}
+					mockFS.MockOpen = func(name string) (fs.File, error) {
+						if name == "mint.yml" {
+							file := mocks.NewFile(originalSpecifiedFileContent)
+							return file, nil
+						} else {
+							Expect(name).To(BeNil())
+							return nil, errors.New("file does not exist")
+						}
+					}
+					mockAPI.MockInitiateRun = func(cfg api.InitiateRunConfig) (*api.InitiateRunResult, error) {
+						Expect(cfg.TaskDefinitions).To(HaveLen(1))
+						Expect(cfg.TaskDefinitions[0].Path).To(Equal(runConfig.MintFilePath))
+						Expect(cfg.MintDirectory).To(HaveLen(0))
+						Expect(cfg.UseCache).To(BeTrue())
+						receivedSpecifiedFileContent = cfg.TaskDefinitions[0].FileContents
+						return &api.InitiateRunResult{
+							RunId:            "785ce4e8-17b9-4c8b-8869-a55e95adffe7",
+							RunURL:           "https://cloud.rwx.com/mint/rwx/runs/785ce4e8-17b9-4c8b-8869-a55e95adffe7",
+							TargetedTaskKeys: []string{},
+							DefinitionPath:   ".mint/mint.yml",
+						}, nil
+					}
+				})
+
+				JustBeforeEach(func() {
+					_, err := service.InitiateRun(runConfig)
+					Expect(err).ToNot(HaveOccurred())
+				})
+
+				It("sends the file contents to cloud", func() {
+					Expect(receivedSpecifiedFileContent).To(Equal(originalSpecifiedFileContent))
+				})
+			})
+
+			Context("when a directory is not found", func() {
+				var originalSpecifiedFileContent string
+				var receivedSpecifiedFileContent string
+
+				BeforeEach(func() {
+					originalSpecifiedFileContent = "tasks:\n  - key: foo\n    run: echo 'bar'\n"
+					receivedSpecifiedFileContent = ""
+					runConfig.MintFilePath = "mint.yml"
+					runConfig.MintDirectory = ""
+
+					mockFS.MockGetwd = func() (string, error) {
+						return "/some/path/to/working/directory", nil
+					}
+					mockFS.MockExists = func(name string) (bool, error) {
+						return false, nil
+					}
+					mockFS.MockOpen = func(name string) (fs.File, error) {
+						if name == "mint.yml" {
+							file := mocks.NewFile(originalSpecifiedFileContent)
+							return file, nil
+						} else {
+							Expect(name).To(BeNil())
+							return nil, errors.New("file does not exist")
+						}
+					}
+					mockAPI.MockInitiateRun = func(cfg api.InitiateRunConfig) (*api.InitiateRunResult, error) {
+						Expect(cfg.TaskDefinitions).To(HaveLen(1))
+						Expect(cfg.TaskDefinitions[0].Path).To(Equal(runConfig.MintFilePath))
+						Expect(cfg.MintDirectory).To(BeNil())
+						Expect(cfg.UseCache).To(BeTrue())
+						receivedSpecifiedFileContent = cfg.TaskDefinitions[0].FileContents
+						return &api.InitiateRunResult{
+							RunId:            "785ce4e8-17b9-4c8b-8869-a55e95adffe7",
+							RunURL:           "https://cloud.rwx.com/mint/rwx/runs/785ce4e8-17b9-4c8b-8869-a55e95adffe7",
+							TargetedTaskKeys: []string{},
+							DefinitionPath:   ".mint/mint.yml",
+						}, nil
+					}
+				})
+
+				JustBeforeEach(func() {
+					_, err := service.InitiateRun(runConfig)
+					Expect(err).ToNot(HaveOccurred())
+				})
+
+				It("sends the file contents to cloud", func() {
+					Expect(receivedSpecifiedFileContent).To(Equal(originalSpecifiedFileContent))
+				})
+			})
+		})
+
+		Context("with no specific mint file and no specific directory", func() {
+			Context("when a directory with files is found", func() {
+				var originalMintDirFileContent string
+				var receivedMintDirFileContent string
+
+				BeforeEach(func() {
+					originalMintDirFileContent = "tasks:\n  - key: mintdir\n    run: echo 'mintdir'\n"
+					receivedMintDirFileContent = ""
+					runConfig.MintFilePath = ""
+					runConfig.MintDirectory = ""
+
+					mockFS.MockGetwd = func() (string, error) {
+						return "/some/path/to/working/directory", nil
+					}
+					mockFS.MockExists = func(name string) (bool, error) {
+						return name == "/some/path/to/.mint", nil
+					}
+					mockFS.MockReadDir = func(name string) ([]fs.DirEntry, error) {
+						Expect(name).To(Equal("/some/path/to/.mint"))
+						return []fs.DirEntry{
+							mocks.DirEntry{FileName: "mintdir-tasks.yml"},
+							mocks.DirEntry{FileName: "mintdir-tasks.json"},
+						}, nil
+					}
+					mockFS.MockOpen = func(name string) (fs.File, error) {
+						if name == "/some/path/to/.mint/mintdir-tasks.yml" {
+							file := mocks.NewFile(originalMintDirFileContent)
+							return file, nil
+						} else {
+							Expect(name).To(BeNil())
+							return nil, errors.New("file does not exist")
+						}
+					}
+					mockAPI.MockInitiateRun = func(cfg api.InitiateRunConfig) (*api.InitiateRunResult, error) {
+						Expect(cfg.TaskDefinitions).To(HaveLen(1))
+						// note that this is relative to cwd and that the mint dir files are in task definitions instead of mint directory
+						Expect(cfg.TaskDefinitions[0].Path).To(Equal("../../.mint/mintdir-tasks.yml"))
+						Expect(cfg.MintDirectory).To(BeNil())
+						Expect(cfg.UseCache).To(BeTrue())
+						receivedMintDirFileContent = cfg.TaskDefinitions[0].FileContents
+						return &api.InitiateRunResult{
+							RunId:            "785ce4e8-17b9-4c8b-8869-a55e95adffe7",
+							RunURL:           "https://cloud.rwx.com/mint/rwx/runs/785ce4e8-17b9-4c8b-8869-a55e95adffe7",
+							TargetedTaskKeys: []string{},
+							DefinitionPath:   ".mint/mint.yml",
+						}, nil
+					}
+				})
+
+				JustBeforeEach(func() {
+					_, err := service.InitiateRun(runConfig)
+					Expect(err).ToNot(HaveOccurred())
+				})
+
+				It("sends the file contents to cloud", func() {
+					Expect(receivedMintDirFileContent).To(Equal(originalMintDirFileContent))
+				})
+			})
+
+			Context("when a directory with invalid files is found", func() {
+				var originalMintDirFileContent string
+
+				BeforeEach(func() {
+					originalMintDirFileContent = "NOT YAML!!!!!!!!"
+					runConfig.MintFilePath = ""
+					runConfig.MintDirectory = ""
+
+					mockFS.MockGetwd = func() (string, error) {
+						return "/some/path/to/working/directory", nil
+					}
+					mockFS.MockExists = func(name string) (bool, error) {
+						return name == "/some/path/to/.mint", nil
+					}
+					mockFS.MockReadDir = func(name string) ([]fs.DirEntry, error) {
+						Expect(name).To(Equal("/some/path/to/.mint"))
+						return []fs.DirEntry{
+							mocks.DirEntry{FileName: "mintdir-tasks.yml"},
+							mocks.DirEntry{FileName: "mintdir-tasks.json"},
+						}, nil
+					}
+					mockFS.MockOpen = func(name string) (fs.File, error) {
+						if name == "/some/path/to/.mint/mintdir-tasks.yml" {
+							file := mocks.NewFile(originalMintDirFileContent)
+							return file, nil
+						} else {
+							Expect(name).To(BeNil())
+							return nil, errors.New("file does not exist")
+						}
+					}
+				})
+
+				It("returns an error", func() {
+					_, err := service.InitiateRun(runConfig)
+					Expect(err).To(HaveOccurred())
+					Expect(err.Error()).To(ContainSubstring("unable to parse"))
+				})
+			})
+
+			Context("when an empty directory is found", func() {
+				BeforeEach(func() {
+					runConfig.MintFilePath = ""
+					runConfig.MintDirectory = ""
+
+					mockFS.MockGetwd = func() (string, error) {
+						return "/some/path/to/working/directory", nil
+					}
+					mockFS.MockExists = func(name string) (bool, error) {
+						return name == "/some/path/to/.mint", nil
+					}
+					mockFS.MockReadDir = func(name string) ([]fs.DirEntry, error) {
+						Expect(name).To(Equal("/some/path/to/.mint"))
+						return []fs.DirEntry{}, nil
+					}
+				})
+
+				It("returns an error", func() {
+					_, err := service.InitiateRun(runConfig)
+					Expect(err).To(HaveOccurred())
+					Expect(err.Error()).To(ContainSubstring("No run definitions provided"))
+				})
+			})
+
+			Context("when a directory is not found", func() {
+				BeforeEach(func() {
+					runConfig.MintFilePath = ""
+					runConfig.MintDirectory = ""
+
+					mockFS.MockGetwd = func() (string, error) {
+						return "/some/path/to/working/directory", nil
+					}
+					mockFS.MockExists = func(name string) (bool, error) {
+						return false, nil
+					}
+				})
+
+				It("returns an error", func() {
+					_, err := service.InitiateRun(runConfig)
+					Expect(err).To(HaveOccurred())
+					Expect(err.Error()).To(ContainSubstring("No run definitions provided"))
+				})
+			})
+		})
+
+		Context("with a specific mint file and a specific directory", func() {
+			Context("when a directory with files is found", func() {
+				var originalSpecifiedFileContent string
+				var originalMintDirFileContent string
+				var receivedSpecifiedFileContent string
+				var receivedMintDirFileContent string
+
+				BeforeEach(func() {
+					originalSpecifiedFileContent = "tasks:\n  - key: foo\n    run: echo 'bar'\n"
+					originalMintDirFileContent = "tasks:\n  - key: mintdir\n    run: echo 'mintdir'\n"
+					receivedSpecifiedFileContent = ""
+					receivedMintDirFileContent = ""
+					runConfig.MintFilePath = "mint.yml"
+					runConfig.MintDirectory = "some-dir"
+
+					mockFS.MockReadDir = func(name string) ([]fs.DirEntry, error) {
+						Expect(name).To(Equal("some-dir"))
+						return []fs.DirEntry{
+							mocks.DirEntry{FileName: "mintdir-tasks.yml"},
+							mocks.DirEntry{FileName: "mintdir-tasks.json"},
+						}, nil
+					}
+					mockFS.MockOpen = func(name string) (fs.File, error) {
+						if name == "mint.yml" {
+							file := mocks.NewFile(originalSpecifiedFileContent)
+							return file, nil
+						} else if name == "some-dir/mintdir-tasks.yml" {
+							file := mocks.NewFile(originalMintDirFileContent)
+							return file, nil
+						} else {
+							Expect(name).To(BeNil())
+							return nil, errors.New("file does not exist")
+						}
+					}
+					mockAPI.MockInitiateRun = func(cfg api.InitiateRunConfig) (*api.InitiateRunResult, error) {
+						Expect(cfg.TaskDefinitions).To(HaveLen(1))
+						Expect(cfg.TaskDefinitions[0].Path).To(Equal(runConfig.MintFilePath))
+						Expect(cfg.MintDirectory).To(HaveLen(1))
+						Expect(cfg.MintDirectory[0].Path).To(Equal(".mint/mintdir-tasks.yml"))
+						Expect(cfg.UseCache).To(BeTrue())
+						receivedSpecifiedFileContent = cfg.TaskDefinitions[0].FileContents
+						receivedMintDirFileContent = cfg.MintDirectory[0].FileContents
+						return &api.InitiateRunResult{
+							RunId:            "785ce4e8-17b9-4c8b-8869-a55e95adffe7",
+							RunURL:           "https://cloud.rwx.com/mint/rwx/runs/785ce4e8-17b9-4c8b-8869-a55e95adffe7",
+							TargetedTaskKeys: []string{},
+							DefinitionPath:   ".mint/mint.yml",
+						}, nil
+					}
+				})
+
+				JustBeforeEach(func() {
+					_, err := service.InitiateRun(runConfig)
+					Expect(err).ToNot(HaveOccurred())
+				})
+
+				It("sends the file contents to cloud", func() {
+					Expect(receivedSpecifiedFileContent).To(Equal(originalSpecifiedFileContent))
+					Expect(receivedMintDirFileContent).To(Equal(originalMintDirFileContent))
+				})
+			})
+
+			Context("when the specified file is invalid", func() {
+				var originalSpecifiedFileContent string
+				var originalMintDirFileContent string
+
+				BeforeEach(func() {
+					originalSpecifiedFileContent = "NOT YAML!!!"
+					originalMintDirFileContent = "tasks:\n  - key: mintdir\n    run: echo 'mintdir'\n"
+					runConfig.MintFilePath = "mint.yml"
+					runConfig.MintDirectory = "some-dir"
+
+					mockFS.MockReadDir = func(name string) ([]fs.DirEntry, error) {
+						Expect(name).To(Equal("some-dir"))
+						return []fs.DirEntry{
+							mocks.DirEntry{FileName: "mintdir-tasks.yml"},
+							mocks.DirEntry{FileName: "mintdir-tasks.json"},
+						}, nil
+					}
+					mockFS.MockOpen = func(name string) (fs.File, error) {
+						if name == "mint.yml" {
+							file := mocks.NewFile(originalSpecifiedFileContent)
+							return file, nil
+						} else if name == "some-dir/mintdir-tasks.yml" {
+							file := mocks.NewFile(originalMintDirFileContent)
+							return file, nil
+						} else {
+							Expect(name).To(BeNil())
+							return nil, errors.New("file does not exist")
+						}
+					}
+				})
+
+				It("returns an error", func() {
+					_, err := service.InitiateRun(runConfig)
+					Expect(err).To(HaveOccurred())
+					Expect(err.Error()).To(ContainSubstring("unable to parse"))
+				})
+			})
+
+			Context("when a directory with invalid files is found", func() {
+				var originalSpecifiedFileContent string
+				var originalMintDirFileContent string
+
+				BeforeEach(func() {
+					originalSpecifiedFileContent = "tasks:\n  - key: foo\n    run: echo 'bar'\n"
+					originalMintDirFileContent = "NOT YAML!!!!!!!!"
+					runConfig.MintFilePath = "mint.yml"
+					runConfig.MintDirectory = "some-dir"
+
+					mockFS.MockReadDir = func(name string) ([]fs.DirEntry, error) {
+						Expect(name).To(Equal("some-dir"))
+						return []fs.DirEntry{
+							mocks.DirEntry{FileName: "mintdir-tasks.yml"},
+							mocks.DirEntry{FileName: "mintdir-tasks.json"},
+						}, nil
+					}
+					mockFS.MockOpen = func(name string) (fs.File, error) {
+						if name == "mint.yml" {
+							file := mocks.NewFile(originalSpecifiedFileContent)
+							return file, nil
+						} else if name == "some-dir/mintdir-tasks.yml" {
+							file := mocks.NewFile(originalMintDirFileContent)
+							return file, nil
+						} else {
+							Expect(name).To(BeNil())
+							return nil, errors.New("file does not exist")
+						}
+					}
+				})
+
+				It("returns an error", func() {
+					_, err := service.InitiateRun(runConfig)
+					Expect(err).To(HaveOccurred())
+					Expect(err.Error()).To(ContainSubstring("unable to parse"))
+				})
+			})
+
+			Context("when an empty directory is found", func() {
+				var originalSpecifiedFileContent string
+				var receivedSpecifiedFileContent string
+
+				BeforeEach(func() {
+					originalSpecifiedFileContent = "tasks:\n  - key: foo\n    run: echo 'bar'\n"
+					receivedSpecifiedFileContent = ""
+					runConfig.MintFilePath = "mint.yml"
+					runConfig.MintDirectory = "some-dir"
+
+					mockFS.MockReadDir = func(name string) ([]fs.DirEntry, error) {
+						Expect(name).To(Equal("some-dir"))
+						return []fs.DirEntry{}, nil
+					}
+					mockFS.MockOpen = func(name string) (fs.File, error) {
+						if name == "mint.yml" {
+							file := mocks.NewFile(originalSpecifiedFileContent)
+							return file, nil
+						} else {
+							Expect(name).To(BeNil())
+							return nil, errors.New("file does not exist")
+						}
+					}
+					mockAPI.MockInitiateRun = func(cfg api.InitiateRunConfig) (*api.InitiateRunResult, error) {
+						Expect(cfg.TaskDefinitions).To(HaveLen(1))
+						Expect(cfg.TaskDefinitions[0].Path).To(Equal(runConfig.MintFilePath))
+						Expect(cfg.MintDirectory).To(HaveLen(0))
+						Expect(cfg.UseCache).To(BeTrue())
+						receivedSpecifiedFileContent = cfg.TaskDefinitions[0].FileContents
+						return &api.InitiateRunResult{
+							RunId:            "785ce4e8-17b9-4c8b-8869-a55e95adffe7",
+							RunURL:           "https://cloud.rwx.com/mint/rwx/runs/785ce4e8-17b9-4c8b-8869-a55e95adffe7",
+							TargetedTaskKeys: []string{},
+							DefinitionPath:   ".mint/mint.yml",
+						}, nil
+					}
+				})
+
+				JustBeforeEach(func() {
+					_, err := service.InitiateRun(runConfig)
+					Expect(err).ToNot(HaveOccurred())
+				})
+
+				It("sends the file contents to cloud", func() {
+					Expect(receivedSpecifiedFileContent).To(Equal(originalSpecifiedFileContent))
+				})
+			})
+
+			Context("when the directory is not found", func() {
+				var originalSpecifiedFileContent string
+
+				BeforeEach(func() {
+					originalSpecifiedFileContent = "tasks:\n  - key: foo\n    run: echo 'bar'\n"
+					runConfig.MintFilePath = "mint.yml"
+					runConfig.MintDirectory = "some-dir"
+
+					mockFS.MockReadDir = func(name string) ([]fs.DirEntry, error) {
+						Expect(name).To(Equal("some-dir"))
+						return nil, os.ErrNotExist
+					}
+					mockFS.MockOpen = func(name string) (fs.File, error) {
+						if name == "mint.yml" {
+							file := mocks.NewFile(originalSpecifiedFileContent)
+							return file, nil
+						} else {
+							Expect(name).To(BeNil())
+							return nil, errors.New("file does not exist")
+						}
+					}
+				})
+
+				It("returns an error", func() {
+					_, err := service.InitiateRun(runConfig)
+					Expect(err).To(HaveOccurred())
+					Expect(err.Error()).To(ContainSubstring("could not be found"))
+				})
+			})
+		})
+
+		Context("with no specific mint file and a specific directory", func() {
+			Context("when a directory with files is found", func() {
+				var originalMintDirFileContent string
+				var receivedMintDirFileContent string
+
+				BeforeEach(func() {
+					originalMintDirFileContent = "tasks:\n  - key: mintdir\n    run: echo 'mintdir'\n"
+					receivedMintDirFileContent = ""
+					runConfig.MintFilePath = ""
+					runConfig.MintDirectory = "some-dir"
+
+					mockFS.MockReadDir = func(name string) ([]fs.DirEntry, error) {
+						Expect(name).To(Equal("some-dir"))
+						return []fs.DirEntry{
+							mocks.DirEntry{FileName: "mintdir-tasks.yml"},
+							mocks.DirEntry{FileName: "mintdir-tasks.json"},
+						}, nil
+					}
+					mockFS.MockOpen = func(name string) (fs.File, error) {
+						if name == "some-dir/mintdir-tasks.yml" {
+							file := mocks.NewFile(originalMintDirFileContent)
+							return file, nil
+						} else {
+							Expect(name).To(BeNil())
+							return nil, errors.New("file does not exist")
+						}
+					}
+					mockAPI.MockInitiateRun = func(cfg api.InitiateRunConfig) (*api.InitiateRunResult, error) {
+						Expect(cfg.TaskDefinitions).To(HaveLen(1))
+						// note that this is the _specified_ dir and path to the file
+						Expect(cfg.TaskDefinitions[0].Path).To(Equal("some-dir/mintdir-tasks.yml"))
+						Expect(cfg.MintDirectory).To(BeNil())
+						Expect(cfg.UseCache).To(BeTrue())
+						receivedMintDirFileContent = cfg.TaskDefinitions[0].FileContents
+						return &api.InitiateRunResult{
+							RunId:            "785ce4e8-17b9-4c8b-8869-a55e95adffe7",
+							RunURL:           "https://cloud.rwx.com/mint/rwx/runs/785ce4e8-17b9-4c8b-8869-a55e95adffe7",
+							TargetedTaskKeys: []string{},
+							DefinitionPath:   ".mint/mint.yml",
+						}, nil
+					}
+				})
+
+				JustBeforeEach(func() {
+					_, err := service.InitiateRun(runConfig)
+					Expect(err).ToNot(HaveOccurred())
+				})
+
+				It("sends the file contents to cloud", func() {
+					Expect(receivedMintDirFileContent).To(Equal(originalMintDirFileContent))
+				})
+			})
+
+			Context("when a directory with invalid files is found", func() {
+				var originalMintDirFileContent string
+
+				BeforeEach(func() {
+					originalMintDirFileContent = "NOT YAML!!!!!!!!"
+					runConfig.MintDirectory = "some-dir"
+
+					mockFS.MockReadDir = func(name string) ([]fs.DirEntry, error) {
+						Expect(name).To(Equal("some-dir"))
+						return []fs.DirEntry{
+							mocks.DirEntry{FileName: "mintdir-tasks.yml"},
+							mocks.DirEntry{FileName: "mintdir-tasks.json"},
+						}, nil
+					}
+					mockFS.MockOpen = func(name string) (fs.File, error) {
+						if name == "some-dir/mintdir-tasks.yml" {
+							file := mocks.NewFile(originalMintDirFileContent)
+							return file, nil
+						} else {
+							Expect(name).To(BeNil())
+							return nil, errors.New("file does not exist")
+						}
+					}
+				})
+
+				It("returns an error", func() {
+					_, err := service.InitiateRun(runConfig)
+					Expect(err).To(HaveOccurred())
+					Expect(err.Error()).To(ContainSubstring("unable to parse"))
+				})
+			})
+
+			Context("when an empty directory is found", func() {
+				BeforeEach(func() {
+					runConfig.MintFilePath = ""
+					runConfig.MintDirectory = "some-dir"
+
+					mockFS.MockReadDir = func(name string) ([]fs.DirEntry, error) {
+						Expect(name).To(Equal("some-dir"))
+						return []fs.DirEntry{}, nil
+					}
+				})
+
+				It("returns an error", func() {
+					_, err := service.InitiateRun(runConfig)
+					Expect(err).To(HaveOccurred())
+					Expect(err.Error()).To(ContainSubstring("No run definitions provided"))
+				})
+			})
+
+			Context("when the directory is not found", func() {
+				BeforeEach(func() {
+					runConfig.MintFilePath = ""
+					runConfig.MintDirectory = "some-dir"
+
+					mockFS.MockReadDir = func(name string) ([]fs.DirEntry, error) {
+						Expect(name).To(Equal("some-dir"))
+						return nil, os.ErrNotExist
+					}
+				})
+
+				It("returns an error", func() {
+					_, err := service.InitiateRun(runConfig)
+					Expect(err).To(HaveOccurred())
+					Expect(err.Error()).To(ContainSubstring("could not be found"))
 				})
 			})
 		})

--- a/internal/fs/file_system.go
+++ b/internal/fs/file_system.go
@@ -5,4 +5,6 @@ type FileSystem interface {
 	Open(name string) (File, error)
 	ReadDir(name string) ([]DirEntry, error)
 	MkdirAll(path string) error
+	Getwd() (string, error)
+	Exists(name string) (bool, error)
 }

--- a/internal/fs/local.go
+++ b/internal/fs/local.go
@@ -43,3 +43,14 @@ func (l Local) ReadDir(name string) ([]DirEntry, error) {
 func (l Local) MkdirAll(path string) error {
 	return os.MkdirAll(path, os.ModePerm)
 }
+
+func (l Local) Getwd() (string, error) {
+	return os.Getwd()
+}
+
+func (l Local) Exists(name string) (bool, error) {
+	_, err := os.Stat(name)
+	if err == nil { return true, nil }
+	if os.IsNotExist(err) { return false, nil }
+	return false, err
+}

--- a/internal/mocks/file_system.go
+++ b/internal/mocks/file_system.go
@@ -10,6 +10,8 @@ type FileSystem struct {
 	MockOpen     func(name string) (fs.File, error)
 	MockReadDir  func(name string) ([]fs.DirEntry, error)
 	MockMkdirAll func(path string) error
+	MockGetwd    func() (string, error)
+	MockExists   func(name string) (bool, error)
 }
 
 func (f *FileSystem) Create(name string) (fs.File, error) {
@@ -42,4 +44,20 @@ func (f *FileSystem) MkdirAll(path string) error {
 	}
 
 	return errors.New("MockMkdirAll was not configured")
+}
+
+func (f *FileSystem) Getwd() (string, error) {
+	if f.MockGetwd != nil {
+		return f.MockGetwd()
+	}
+
+	return "", errors.New("MockGetwd was not configured")
+}
+
+func (f *FileSystem) Exists(name string) (bool, error) {
+	if f.MockExists != nil {
+		return f.MockExists(name)
+	}
+
+	return false, errors.New("MockExists was not configured")
 }


### PR DESCRIPTION
With the upcoming release of Embedded Runs, we need to better define the behavior around `--dir` and `--file`.

Previously, these flags were mutually exclusive. You could provide:
- Nothing. In this case, we'd look in `.mint` in your working directory and try to run any task definitions at the top-level of that folder
- `--dir some-dir`. In this case, we'd look in that directory for run definitions and try to run them
- `--file some-file.yml`. In this case, we'd ignore any `.mint` directories and simply send the one task definition you specified

Moving forward, embedded runs need the context of a `.mint` dir to populate the run definitions that can be statically embedded (via `call: ${{ mint.run-dir }}/tasks.yml`). To facilitate this, the CLI needs to differentiate between the task definitions that we intend to run and the ones which should be treated as the mint dir for a run.

Now, you can provide:
- Nothing. In this case, we'll start in the working directory and traverse up until we find a `.mint` dir no no `.mint` dir
- `--dir some-dir --file somewhere-else/tasks.yml`. In this case, the contents of `some-dir` can be referenced by static embedded runs and `somewhere-else/tasks.yml` will be the definition we use to start your run
- `--dir some-dir`. In this case, we'll read the contents of `some-dir`, use it as the mint dir for embedded runs _and_ try to start runs with the definitions in the directory
- `--file somewhere-else/tasks.yml`. In this case, we'll perform the traversal logic to populate the mint dir and use `somewhere-else/tasks.yml` to start your run