### PR TITLE
Clean up whitespace surrounding the token in case it was manually set

### DIFF
--- a/internal/accesstoken/file_backend.go
+++ b/internal/accesstoken/file_backend.go
@@ -45,7 +45,7 @@ func (f FileBackend) Get() (string, error) {
 		return "", errors.Wrapf(err, "error reading %q", filepath)
 	}
 
-	return string(contents), nil
+	return strings.TrimSpace(string(contents)), nil
 }
 
 func (f FileBackend) Set(value string) error {

--- a/internal/accesstoken/file_backend_test.go
+++ b/internal/accesstoken/file_backend_test.go
@@ -74,6 +74,24 @@ var _ = Describe("FileBackend", func() {
 				Expect(token).To(Equal("the-token"))
 			})
 		})
+
+		Context("when the access token file includes leading or trailing whitespace", func() {
+			BeforeEach(func() {
+				mockFS.MockOpen = func(name string) (fs.File, error) {
+					Expect(name).To(Equal("some/dir/accesstoken"))
+					return mocks.NewFile("\n  \t  the-token\t  \n \n"), nil
+				}
+			})
+
+			It("returns the token with surrounding whitespace trimmed", func() {
+				backend, err := accesstoken.NewFileBackend("some/dir", mockFS)
+				Expect(err).NotTo(HaveOccurred())
+
+				token, err := backend.Get()
+				Expect(err).NotTo(HaveOccurred())
+				Expect(token).To(Equal("the-token"))
+			})
+		})
 	})
 
 	Describe("Set", func() {


### PR DESCRIPTION
Editors often pad files with a trailing newline. When setting `~/.mint/accesstoken` manually, this was causing errors when usinng the token in http requests (a newline is not valid in the header)