### PR TITLE
Don't require authentication to list Mint leaves via API.

### DIFF
--- a/cmd/mint/leaves.go
+++ b/cmd/mint/leaves.go
@@ -17,9 +17,6 @@ var (
 	AllowMajorVersionChange bool
 
 	leavesUpdateCmd = &cobra.Command{
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return requireAccessToken()
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			replacementVersionPicker := cli.PickLatestMinorVersion
 			if AllowMajorVersionChange {


### PR DESCRIPTION
We've removed the requirement from the API for authentication to this endpoint.