### PR TITLE
Print user-facing error message on 410 reponse when debugging

### DIFF
--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -77,6 +77,10 @@ func (c Client) GetDebugConnectionInfo(debugKey string) (DebugConnectionInfo, er
 	case 404:
 		return connectionInfo, errors.ErrNotFound
 	case 410:
+		connectionError := DebugConnectionInfoError{}
+		if err := json.NewDecoder(resp.Body).Decode(&connectionError); err == nil {
+			return connectionInfo, errors.New(connectionError.Error)
+		}
 		return connectionInfo, errors.ErrGone
 	default:
 		return connectionInfo, errors.New(fmt.Sprintf("Unable to call Mint API - %s", resp.Status))


### PR DESCRIPTION
We currently only print a server-provided error message on 400. This also adds it to 410