### PR TITLE
Fixes the release build

### DIFF
--- a/.mint/release.yml
+++ b/.mint/release.yml
@@ -144,9 +144,9 @@ tasks:
         extension=".exe"
       fi
 
-      CGO_ENABLED=0 \
-      LDFLAGS="-w -s -X github.com/rwx-research/mint-cli/cmd/mint/config.Version=${{ tasks.extract-version-details.values.full-version }}" \
-      go run ./tools/mage -compile "mint$extension" -goos ${{ parallel.os }} -goarch ${{ parallel.arch }}
+      GOOS=${{ parallel.os }} \
+      GOARCH=${{ parallel.arch }} \
+      go build -ldflags "-w -s -X github.com/rwx-research/mint-cli/cmd/mint/config.Version=${{ tasks.extract-version-details.values.full-version }}" -a ./cmd/mint
 
       if [[ ${{ parallel.os }} == "darwin" ]]; then
         echo "$RWX_APPLE_DEVELOPER_ID_APPLICATION_CERT" > rwx-developer-id-application-cert.pem


### PR DESCRIPTION
When we switched this off of nix, we must have misunderstood what the `-compile` flag does. It builds a static binary _of mage_, not of your CLI.

For some reason I couldn't get `mage build` to work. It was trying to execute the version of mage for the platform we were trying to build for (e.g. the windows build was trying to execute mage.exe). This should have been fixed in https://github.com/magefile/mage/pull/202 but it seems like it wasn't. I decided to bypass mage altogether for the sake of expediency.

Tested with this release: https://github.com/rwx-research/mint-cli/releases/tag/untagged-ce7a12e2f5930bf6d86a