### PR TITLE
Add `mint lint` command.

### DIFF
--- a/cmd/mint/lint.go
+++ b/cmd/mint/lint.go
@@ -1,0 +1,70 @@
+package main
+
+import (
+	"errors"
+	"os"
+	"slices"
+
+	"github.com/rwx-research/mint-cli/internal/api"
+	"github.com/rwx-research/mint-cli/internal/cli"
+
+	"github.com/spf13/cobra"
+)
+
+var (
+	LintFailure = errors.New("lint failure")
+
+	LintMintDirectory    string
+	LintWarningsAsErrors bool
+	LintOutputFormat     string
+
+	lintCmd = &cobra.Command{
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			return requireAccessToken()
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			var targetedFiles []string
+			if len(args) >= 0 {
+				targetedFiles = args
+			}
+
+			lintConfig, err := cli.NewLintConfig(
+				targetedFiles,
+				LintMintDirectory,
+				os.Stdout,
+				LintOutputFormat,
+			)
+			if err != nil {
+				return err
+			}
+
+			lintResult, err := service.Lint(lintConfig)
+			if err != nil {
+				return err
+			}
+
+			if len(lintResult.Problems) == 0 {
+				return nil
+			}
+
+			hasError := slices.ContainsFunc(lintResult.Problems, func(lf api.LintProblem) bool {
+				return lf.Severity == "error"
+			})
+
+			if hasError || LintWarningsAsErrors {
+				return LintFailure
+			}
+
+			return nil
+		},
+		Short:  "Lint Mint configuration files",
+		Use:    "lint [flags] [files...]",
+		Hidden: true,
+	}
+)
+
+func init() {
+	lintCmd.Flags().BoolVar(&LintWarningsAsErrors, "warnings-as-errors", false, "treat warnings as errors")
+	lintCmd.Flags().StringVarP(&LintMintDirectory, "dir", "d", "", "the directory your Mint files are located in, typically `.mint`. By default, the CLI traverses up until it finds a `.mint` directory.")
+	lintCmd.Flags().StringVarP(&LintOutputFormat, "output", "o", "multiline", "output format: multiline, oneline, none")
+}

--- a/cmd/mint/main.go
+++ b/cmd/mint/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"os"
 )
@@ -11,11 +12,13 @@ func main() {
 		return
 	}
 
-	if Debug {
-		// Enabling debug output will print stacktraces
-		fmt.Fprintf(os.Stderr, "Error: %+v\n", err)
-	} else {
-		fmt.Fprintf(os.Stderr, "Error: %s\n", err)
+	if !errors.Is(err, LintFailure) {
+		if Debug {
+			// Enabling debug output will print stacktraces
+			fmt.Fprintf(os.Stderr, "Error: %+v\n", err)
+		} else {
+			fmt.Fprintf(os.Stderr, "Error: %s\n", err)
+		}
 	}
 
 	os.Exit(1)

--- a/cmd/mint/root.go
+++ b/cmd/mint/root.go
@@ -71,4 +71,5 @@ func init() {
 	rootCmd.AddCommand(whoamiCmd)
 	rootCmd.AddCommand(vaultsCmd)
 	rootCmd.AddCommand(leavesCmd)
+	rootCmd.AddCommand(lintCmd)
 }

--- a/cmd/mint/run.go
+++ b/cmd/mint/run.go
@@ -109,7 +109,7 @@ func init() {
 	runCmd.Flags().BoolVar(&NoCache, "no-cache", false, "do not read or write to the cache")
 	runCmd.Flags().StringArrayVar(&InitParameters, flagInit, []string{}, "initialization parameters for the run, available in the `init` context. Can be specified multiple times")
 	runCmd.Flags().StringVarP(&MintFilePath, "file", "f", "", "a Mint config file to use for sourcing task definitions (required)")
-	runCmd.Flags().StringVarP(&MintDirectory, "dir", "d", "", "the directory your Mint files are located in, typicalling `.mint`. By default, the CLI traverses up until it finds a `.mint` directory.")
+	runCmd.Flags().StringVarP(&MintDirectory, "dir", "d", "", "the directory your Mint files are located in, typically `.mint`. By default, the CLI traverses up until it finds a `.mint` directory.")
 	runCmd.Flags().BoolVar(&Open, "open", false, "open the run in a browser")
 	runCmd.Flags().StringVar(&Title, "title", "", "the title the UI will display for the Mint run")
 	runCmd.Flags().BoolVar(&Json, "json", false, "output json data to stdout")

--- a/internal/api/nullable.go
+++ b/internal/api/nullable.go
@@ -1,0 +1,57 @@
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+)
+
+type NullInt struct {
+	Value  int
+	IsNull bool
+}
+
+func NewNullInt(value int) NullInt {
+	return NullInt{
+		Value:  value,
+		IsNull: false,
+	}
+}
+
+func (ni NullInt) MarshalJSON() ([]byte, error) {
+	if ni.IsNull {
+		return []byte("null"), nil
+	}
+	return []byte(strconv.FormatInt(int64(ni.Value), 10)), nil
+}
+
+func (ni *NullInt) UnmarshalJSON(data []byte) error {
+	if len(data) == 0 {
+		return fmt.Errorf("UnmarshalJSON: no data")
+	}
+
+	switch data[0] {
+	case 'n':
+		ni.Value = 0
+		ni.IsNull = true
+		return nil
+
+	case '"':
+		var str string
+		if err := json.Unmarshal(data, &str); err != nil {
+			return fmt.Errorf("null: couldn't unmarshal number string: %w", err)
+		}
+		n, err := strconv.ParseInt(str, 10, strconv.IntSize)
+		if err != nil {
+			return fmt.Errorf("null: couldn't convert string to int: %w", err)
+		}
+		ni.Value = int(n)
+		ni.IsNull = false
+		return nil
+
+	default:
+		err := json.Unmarshal(data, &ni.Value)
+		ni.IsNull = err != nil
+		return err
+	}
+}

--- a/internal/api/task_definition.go
+++ b/internal/api/task_definition.go
@@ -2,5 +2,5 @@ package api
 
 type TaskDefinition struct {
 	Path         string `json:"path"`
-	FileContents string `json:"file_contents"` // This type is expected by cloud
+	FileContents string `json:"file_contents"`
 }

--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -61,6 +61,47 @@ func (c InitiateRunConfig) Validate() error {
 	return nil
 }
 
+type LintOutputFormat int
+
+const (
+	LintOutputNone LintOutputFormat = iota
+	LintOutputOneLine
+	LintOutputMultiLine
+)
+
+type LintConfig struct {
+	MintDirectory string
+	MintFilePaths []string
+	Output        io.Writer
+	OutputFormat  LintOutputFormat
+}
+
+func (c LintConfig) Validate() error {
+	return nil
+}
+
+func NewLintConfig(filePaths []string, mintDir string, output io.Writer, formatString string) (LintConfig, error) {
+	var format LintOutputFormat
+
+	switch formatString {
+	case "none":
+		format = LintOutputNone
+	case "oneline":
+		format = LintOutputOneLine
+	case "multiline":
+		format = LintOutputMultiLine
+	default:
+		return LintConfig{}, errors.New("unknown output format, expected one of: none, oneline, multiline")
+	}
+
+	return LintConfig{
+		MintDirectory: mintDir,
+		MintFilePaths: filePaths,
+		Output:        output,
+		OutputFormat:  format,
+	}, nil
+}
+
 type LoginConfig struct {
 	DeviceName         string
 	AccessTokenBackend accesstoken.Backend

--- a/internal/cli/interfaces.go
+++ b/internal/cli/interfaces.go
@@ -11,6 +11,7 @@ type APIClient interface {
 	InitiateRun(api.InitiateRunConfig) (*api.InitiateRunResult, error)
 	ObtainAuthCode(api.ObtainAuthCodeConfig) (*api.ObtainAuthCodeResult, error)
 	AcquireToken(tokenUrl string) (*api.AcquireTokenResult, error)
+	Lint(api.LintConfig) (*api.LintResult, error)
 	Whoami() (*api.WhoamiResult, error)
 	SetSecretsInVault(api.SetSecretsInVaultConfig) (*api.SetSecretsInVaultResult, error)
 	GetLeafVersions() (*api.LeafVersionsResult, error)

--- a/internal/cli/service.go
+++ b/internal/cli/service.go
@@ -315,12 +315,7 @@ func outputLintOneLine(w io.Writer, lintedFiles []api.LintProblem) error {
 			fmt.Fprint(w, fileLoc, " - ")
 		}
 
-		fmt.Fprint(w, strings.ReplaceAll(lf.Message, "\n", " "))
-
-		if len(lf.Advice) > 0 {
-			fmt.Fprintf(w, " %s", strings.ReplaceAll(lf.Advice, "\n", " "))
-		}
-
+		fmt.Fprint(w, strings.TrimSuffix(strings.ReplaceAll(lf.Message, "\n", " "), " "))
 		fmt.Fprintln(w)
 	}
 

--- a/internal/cli/service.go
+++ b/internal/cli/service.go
@@ -1,12 +1,14 @@
 package cli
 
 import (
+	"cmp"
 	"encoding/json"
 	"fmt"
 	"io"
 	"os"
 	"path/filepath"
 	"regexp"
+	"slices"
 	"strings"
 	"time"
 
@@ -172,6 +174,173 @@ func (s Service) InitiateRun(cfg InitiateRunConfig) (*api.InitiateRunResult, err
 	}
 
 	return runResult, nil
+}
+
+func (s Service) Lint(cfg LintConfig) (*api.LintResult, error) {
+	err := cfg.Validate()
+	if err != nil {
+		return nil, errors.Wrap(err, "validation failed")
+	}
+
+	configFilePaths := cfg.MintFilePaths
+
+	// Ensure both the provided paths and everything in the MintDirectory is loaded.
+	mintDirectoryPath, err := s.findMintDirectoryPath(cfg.MintDirectory)
+	if err != nil {
+		return nil, fmt.Errorf("You specified a mint directory of %q, but %q could not be found", cfg.MintDirectory, cfg.MintDirectory)
+	}
+	configFilePaths = append(configFilePaths, mintDirectoryPath)
+	configFilePaths = removeDuplicateStrings(configFilePaths)
+
+	taskDefinitionYamlPaths := make([]string, 0)
+
+	for _, fileOrDir := range configFilePaths {
+		fi, err := s.Config.FileSystem.Stat(fileOrDir)
+		if err != nil {
+			if errors.Is(err, errors.ErrFileNotExists) {
+				return nil, fmt.Errorf("you specified %q, but %q could not be found", fileOrDir, fileOrDir)
+			}
+			return nil, errors.Wrap(err, "unable to find file or directory")
+		}
+
+		if fi.IsDir() {
+			paths, err := s.yamlFilePathsInDirectory(fileOrDir)
+			if err != nil {
+				return nil, errors.Wrap(err, "unable to find yaml files in directory")
+			}
+			taskDefinitionYamlPaths = append(taskDefinitionYamlPaths, paths...)
+		} else {
+			taskDefinitionYamlPaths = append(taskDefinitionYamlPaths, fileOrDir)
+		}
+	}
+
+	wd, err := s.Config.FileSystem.Getwd()
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to get current working directory")
+	}
+
+	// Normalize paths to be relative to current working directory.
+	relativeTaskDefinitionYamlPaths := make([]string, len(taskDefinitionYamlPaths))
+	for i, yamlPath := range taskDefinitionYamlPaths {
+		if relativePath, err := filepath.Rel(wd, yamlPath); err == nil {
+			relativeTaskDefinitionYamlPaths[i] = relativePath
+		} else {
+			relativeTaskDefinitionYamlPaths[i] = yamlPath
+		}
+	}
+	relativeTaskDefinitionYamlPaths = removeDuplicateStrings(relativeTaskDefinitionYamlPaths)
+
+	taskDefinitions, err := s.taskDefinitionsFromPaths(relativeTaskDefinitionYamlPaths)
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to read provided files")
+	}
+	taskDefinitions = removeDuplicates(taskDefinitions, func(td api.TaskDefinition) string {
+		return td.Path
+	})
+
+	var targetPaths []string
+	if len(cfg.MintFilePaths) > 0 {
+		targetPaths = make([]string, len(cfg.MintFilePaths))
+
+		for i, yamlPath := range cfg.MintFilePaths {
+			if relativePath, err := filepath.Rel(wd, yamlPath); err == nil {
+				targetPaths[i] = relativePath
+			} else {
+				targetPaths[i] = yamlPath
+			}
+		}
+		targetPaths = removeDuplicateStrings(targetPaths)
+	} else {
+		targetPaths = relativeTaskDefinitionYamlPaths
+	}
+
+	lintResult, err := s.APIClient.Lint(api.LintConfig{
+		TaskDefinitions: taskDefinitions,
+		TargetPaths:     targetPaths,
+	})
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to lint files")
+	}
+
+	switch cfg.OutputFormat {
+	case LintOutputOneLine:
+		err = outputLintOneLine(cfg.Output, sortLintProblems(lintResult.Problems))
+	case LintOutputMultiLine:
+		err = outputLintMultiLine(cfg.Output, sortLintProblems(lintResult.Problems))
+	}
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to output lint results")
+	}
+
+	return lintResult, nil
+}
+
+func outputLintMultiLine(w io.Writer, lintedFiles []api.LintProblem) error {
+	if len(lintedFiles) == 0 {
+		return nil
+	}
+
+	for i, lf := range lintedFiles {
+		if i > 0 {
+			fmt.Fprintln(w)
+		}
+
+		if fileLoc := lf.FileLocation(); len(fileLoc) > 0 {
+			fmt.Fprint(w, fileLoc, "  ")
+		}
+		fmt.Fprint(w, "[", lf.Severity, "]")
+		fmt.Fprintln(w)
+
+		fmt.Fprint(w, lf.Message)
+
+		if len(lf.Advice) > 0 {
+			fmt.Fprint(w, "\n", lf.Advice)
+		}
+
+		fmt.Fprintln(w)
+	}
+
+	return nil
+}
+
+func outputLintOneLine(w io.Writer, lintedFiles []api.LintProblem) error {
+	if len(lintedFiles) == 0 {
+		return nil
+	}
+
+	for _, lf := range lintedFiles {
+		fmt.Fprintf(w, "%-8s", lf.Severity)
+
+		if fileLoc := lf.FileLocation(); len(fileLoc) > 0 {
+			fmt.Fprint(w, fileLoc, " - ")
+		}
+
+		fmt.Fprint(w, strings.ReplaceAll(lf.Message, "\n", " "))
+
+		if len(lf.Advice) > 0 {
+			fmt.Fprintf(w, " %s", strings.ReplaceAll(lf.Advice, "\n", " "))
+		}
+
+		fmt.Fprintln(w)
+	}
+
+	return nil
+}
+
+func sortLintProblems(problems []api.LintProblem) []api.LintProblem {
+	sortedProblems := append([]api.LintProblem(nil), problems...)
+	slices.SortFunc(sortedProblems, func(a, b api.LintProblem) int {
+		if n := cmp.Compare(a.FileName, b.FileName); n != 0 {
+			return n
+		}
+
+		if n := cmp.Compare(a.Line.Value, b.Line.Value); n != 0 {
+			return n
+		}
+
+		return cmp.Compare(a.Column.Value, b.Column.Value)
+	})
+	return sortedProblems
 }
 
 // InitiateRun will connect to the Cloud API and start a new run in Mint.
@@ -582,4 +751,23 @@ func PickLatestMinorVersion(versions api.LeafVersionsResult, leaf string, major 
 	}
 
 	return latestVersion, nil
+}
+
+func removeDuplicateStrings(list []string) []string {
+	slices.Sort(list)
+	return slices.Compact(list)
+}
+
+func removeDuplicates[T any, K comparable](list []T, identity func(t T) K) []T {
+	seen := make(map[K]bool)
+	var ts []T
+
+	for _, t := range list {
+		id := identity(t)
+		if _, found := seen[id]; !found {
+			seen[id] = true
+			ts = append(ts, t)
+		}
+	}
+	return ts
 }

--- a/internal/cli/service_test.go
+++ b/internal/cli/service_test.go
@@ -1620,8 +1620,8 @@ AAAEC6442PQKevgYgeT0SIu9zwlnEMl6MF59ZgM+i0ByMv4eLJPqG3xnZcEQmktHj/GY2i
 					_, err := service.Lint(lintConfig)
 					Expect(err).NotTo(HaveOccurred())
 					Expect(stdout.String()).To(Equal(`warning mint1.yml - message 4
-warning mint1.yml:2:6 - message 3 advice 3 advice 3a
-error   mint1.yml:11:22 - message 1 message 1a advice 1 advice 1a
+warning mint1.yml:2:6 - message 3
+error   mint1.yml:11:22 - message 1 message 1a
 error   mint1.yml:15:4 - message 2 message 2a
 `))
 				})

--- a/internal/fs/file.go
+++ b/internal/fs/file.go
@@ -2,6 +2,4 @@ package fs
 
 import "io"
 
-type File interface {
-	io.ReadWriteCloser
-}
+type File io.ReadWriteCloser

--- a/internal/memoryfs/file_system.go
+++ b/internal/memoryfs/file_system.go
@@ -191,23 +191,37 @@ func (mfs *MemoryFS) Entries() map[string]*MemFile {
 	return maps.Clone(mfs.entries)
 }
 
+// WriteFile creates a file at the given path, including any necessary directory structure.
+func (mfs *MemoryFS) WriteFile(name string, contents []byte) error {
+	name = mfs.abs(name)
+	dir := path.Dir(name)
+	if err := mfs.MkdirAll(dir); err != nil {
+		return err
+	}
+
+	file, err := mfs.Create(name)
+	if err != nil {
+		return err
+	}
+	if _, err = file.Write(contents); err != nil {
+		return err
+	}
+	if err = file.Close(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// WriteFileString creates a file at the given path, including any necessary directory structure.
+func (mfs *MemoryFS) WriteFileString(name string, contents string) error {
+	return mfs.WriteFile(name, []byte(contents))
+}
+
 // WriteFiles creates the given files, including any necessary directory structure.
 func (mfs *MemoryFS) WriteFiles(files map[string][]byte) error {
 	for name, contents := range files {
-		name = mfs.abs(name)
-		dir := path.Dir(name)
-		if err := mfs.MkdirAll(dir); err != nil {
-			return err
-		}
-
-		file, err := mfs.Create(name)
-		if err != nil {
-			return err
-		}
-		if _, err = file.Write(contents); err != nil {
-			return err
-		}
-		if err = file.Close(); err != nil {
+		if err := mfs.WriteFile(name, contents); err != nil {
 			return err
 		}
 	}

--- a/internal/mocks/api.go
+++ b/internal/mocks/api.go
@@ -13,6 +13,7 @@ type API struct {
 	MockWhoami                 func() (*api.WhoamiResult, error)
 	MockSetSecretsInVault      func(api.SetSecretsInVaultConfig) (*api.SetSecretsInVaultResult, error)
 	MockGetLeafVersions        func() (*api.LeafVersionsResult, error)
+	MockLint                   func(api.LintConfig) (*api.LintResult, error)
 }
 
 func (c *API) InitiateRun(cfg api.InitiateRunConfig) (*api.InitiateRunResult, error) {
@@ -69,4 +70,12 @@ func (c *API) GetLeafVersions() (*api.LeafVersionsResult, error) {
 	}
 
 	return nil, errors.New("MockGetLeafVersions was not configured")
+}
+
+func (c *API) Lint(cfg api.LintConfig) (*api.LintResult, error) {
+	if c.MockLint != nil {
+		return c.MockLint(cfg)
+	}
+
+	return nil, errors.New("MockLint was not configured")
 }

--- a/internal/mocks/file_system.go
+++ b/internal/mocks/file_system.go
@@ -12,7 +12,7 @@ type FileSystem struct {
 	MockMkdirAll func(path string) error
 	MockGetwd    func() (string, error)
 	MockExists   func(name string) (bool, error)
-	MockStat     func(name string) (DirEntry, error)
+	MockStat     func(name string) (fs.DirEntry, error)
 }
 
 func (f *FileSystem) Create(name string) (fs.File, error) {
@@ -58,6 +58,11 @@ func (f *FileSystem) Getwd() (string, error) {
 func (f *FileSystem) Exists(name string) (bool, error) {
 	if f.MockExists != nil {
 		return f.MockExists(name)
+	}
+
+	if f.MockStat != nil {
+		_, err := f.MockStat(name)
+		return err == nil, err
 	}
 
 	return false, errors.New("MockExists was not configured")


### PR DESCRIPTION
Add `mint lint` as a hidden/beta feature. When this command is stable we will include it in the list of available commands in `mint help`.

Output options include `oneline`:

```text
error   .mint/continuous_integration.yml:13:5 - Unexpected property `bad`
error   .mint/continuous_integration.yml:27:5 - Unexpected property `wat`
error   .mint/run-bad.yml:2:5 - Expected a task with a `run` key, a leaf with a `call` key, or an embedded run with a `call` key
```

`multiline`:

```text
.mint/continuous_integration.yml:13:5  [error]
Unexpected property `bad`
Expected one of the following keys: `id`, `if`, `capacity`, `on-overflow`

.mint/continuous_integration.yml:27:5  [error]
Unexpected property `wat`
Expected one of the following keys: `key`, `use`, `after`, `if`, `filter`, `cache`, `call`, `with`, `parallel`

.mint/run-bad.yml:2:5  [error]
Expected a task with a `run` key, a leaf with a `call` key, or an embedded run with a `call` key
```

and `none`.

The exit status will be `1` if there are any errors, or if there are warnings and the option `--warnings-as-errors` is used. Otherwise, the exit status will be `0`.