### PR TITLE
Include final counts in multiline mint-lint output.

### DIFF
--- a/internal/cli/service.go
+++ b/internal/cli/service.go
@@ -266,7 +266,7 @@ func (s Service) Lint(cfg LintConfig) (*api.LintResult, error) {
 	case LintOutputOneLine:
 		err = outputLintOneLine(cfg.Output, sortLintProblems(lintResult.Problems))
 	case LintOutputMultiLine:
-		err = outputLintMultiLine(cfg.Output, sortLintProblems(lintResult.Problems))
+		err = outputLintMultiLine(cfg.Output, sortLintProblems(lintResult.Problems), len(targetPaths))
 	}
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to output lint results")
@@ -275,12 +275,8 @@ func (s Service) Lint(cfg LintConfig) (*api.LintResult, error) {
 	return lintResult, nil
 }
 
-func outputLintMultiLine(w io.Writer, lintedFiles []api.LintProblem) error {
-	if len(lintedFiles) == 0 {
-		return nil
-	}
-
-	for i, lf := range lintedFiles {
+func outputLintMultiLine(w io.Writer, problems []api.LintProblem, fileCount int) error {
+	for i, lf := range problems {
 		if i > 0 {
 			fmt.Fprintln(w)
 		}
@@ -299,6 +295,13 @@ func outputLintMultiLine(w io.Writer, lintedFiles []api.LintProblem) error {
 
 		fmt.Fprintln(w)
 	}
+
+	pluralized := "problems"
+	if len(problems) == 1 {
+		pluralized = "problem"
+	}
+
+	fmt.Fprintf(w, "\nChecked %d files and found %d %s.\n", fileCount, len(problems), pluralized)
 
 	return nil
 }

--- a/internal/cli/service_test.go
+++ b/internal/cli/service_test.go
@@ -1652,6 +1652,8 @@ advice 1a
 mint1.yml:15:4  [error]
 message 2
 message 2a
+
+Checked 2 files and found 4 problems.
 `))
 				})
 			})
@@ -1700,10 +1702,10 @@ message 2a
 					lintConfig.OutputFormat = cli.LintOutputMultiLine
 				})
 
-				It("doesn't output", func() {
+				It("outputs check counts", func() {
 					_, err := service.Lint(lintConfig)
 					Expect(err).NotTo(HaveOccurred())
-					Expect(stdout.String()).To(Equal(""))
+					Expect(stdout.String()).To(Equal("\nChecked 2 files and found 0 problems.\n"))
 				})
 			})
 


### PR DESCRIPTION
Includes detail on the number of files checked by `mint lint` when multiline output is used.

```
.mint/release.yml:110:5  [error]
Unexpected property `enX`
Expected one of the following keys: `agent`, `key`, `use`, `after`, `if`, `filter`, `cache`, `run`, `background-processes`, `outputs`, `env`, `env-config`, `timeout-minutes`, `tool-cache`, `parallel`, `docker`

Checked 4 files and found 1 problem.
```