### PR TITLE
Adds support for new user message format for runs and linting

### DIFF
--- a/internal/cli/service.go
+++ b/internal/cli/service.go
@@ -158,7 +158,7 @@ func (s Service) InitiateRun(cfg InitiateRunConfig) (*api.InitiateRunResult, err
 		UseCache:                 !cfg.NoCache,
 	})
 	if err != nil {
-		return nil, errors.Wrap(err, "Failed to initiated run")
+		return nil, errors.Wrap(err, "Failed to initiate run")
 	}
 
 	return runResult, nil

--- a/internal/cli/service_test.go
+++ b/internal/cli/service_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/rwx-research/mint-cli/internal/errors"
 	"github.com/rwx-research/mint-cli/internal/fs"
 	"github.com/rwx-research/mint-cli/internal/memoryfs"
+	"github.com/rwx-research/mint-cli/internal/messages"
 	"github.com/rwx-research/mint-cli/internal/mocks"
 
 	"golang.org/x/crypto/ssh"
@@ -1452,13 +1453,13 @@ AAAEC6442PQKevgYgeT0SIu9zwlnEMl6MF59ZgM+i0ByMv4eLJPqG3xnZcEQmktHj/GY2i
 					lintConfig.OutputFormat = cli.LintOutputOneLine
 				})
 
-				It("orders and lists only files", func() {
+				It("lists only files", func() {
 					_, err := service.Lint(lintConfig)
 					Expect(err).NotTo(HaveOccurred())
-					Expect(stdout.String()).To(Equal(`warning mint1.yml - message 4
-warning mint1.yml:2:6 - message 3
-error   mint1.yml:11:22 - message 1 message 1a
+					Expect(stdout.String()).To(Equal(`error   mint1.yml:11:22 - message 1 message 1a
 error   mint1.yml:15:4 - message 2 message 2a
+warning mint1.yml:2:6 - message 3
+warning mint1.yml - message 4
 `))
 				})
 			})
@@ -1468,17 +1469,10 @@ error   mint1.yml:15:4 - message 2 message 2a
 					lintConfig.OutputFormat = cli.LintOutputMultiLine
 				})
 
-				It("orders and lists only files", func() {
+				It("lists all the data from the problem", func() {
 					_, err := service.Lint(lintConfig)
 					Expect(err).NotTo(HaveOccurred())
-					Expect(stdout.String()).To(Equal(`mint1.yml  [warning]
-message 4
-
-mint1.yml:2:6  [warning]
-message 3
-advice 3
-advice 3a
-
+					Expect(stdout.String()).To(Equal(`
 mint1.yml:11:22  [error]
 message 1
 message 1a
@@ -1488,6 +1482,151 @@ advice 1a
 mint1.yml:15:4  [error]
 message 2
 message 2a
+
+mint1.yml:2:6  [warning]
+message 3
+advice 3
+advice 3a
+
+mint1.yml  [warning]
+message 4
+
+Checked 2 files and found 4 problems.
+`))
+				})
+			})
+
+			Context("using none output", func() {
+				BeforeEach(func() {
+					lintConfig.OutputFormat = cli.LintOutputNone
+				})
+
+				It("doesn't output", func() {
+					_, err := service.Lint(lintConfig)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(stdout.String()).To(Equal(""))
+				})
+			})
+		})
+
+		Context("with multiple errors including stack traces", func() {
+			BeforeEach(func() {
+				Expect(memfs.WriteFileString("mint1.yml", "mint1 contents")).NotTo(HaveOccurred())
+				Expect(memfs.WriteFileString(".mint/base.yml", ".mint/base.yml contents")).NotTo(HaveOccurred())
+				Expect(memfs.WriteFileString(".mint/base.json", ".mint/base.json contents")).NotTo(HaveOccurred())
+
+				lintConfig.MintFilePaths = []string{"mint1.yml", ".mint/base.yml"}
+
+				mockAPI.MockLint = func(cfg api.LintConfig) (*api.LintResult, error) {
+					Expect(cfg.TaskDefinitions).To(HaveLen(2))
+					return &api.LintResult{
+						Problems: []api.LintProblem{
+							{
+								Severity: "error",
+								Message: "message 1\nmessage 1a",
+								StackTrace: []messages.StackEntry{
+									{
+											FileName: "mint1.yml",
+											Line:     11,
+											Column:   22,
+									},
+								},
+								Frame: "  4 |     run: echo hi\n> 5 |     bad: true\n    |     ^\n  6 |     env:\n  7 |       A:",
+								Advice: "advice 1\nadvice 1a",
+							},
+							{
+								Severity: "error",
+								Message: "message 2\nmessage 2a",
+								StackTrace: []messages.StackEntry{
+									{
+											FileName: "mint1.yml",
+											Line:     22,
+											Column:   11,
+											Name:     "*alias",
+									},
+									{
+											FileName: "mint1.yml",
+											Line:     5,
+											Column:   22,
+									},
+								},
+							},
+							{
+								Severity: "warning",
+								Message: "message 3",
+								StackTrace: []messages.StackEntry{
+									{
+											FileName: "mint1.yml",
+											Line:     2,
+											Column:   6,
+									},
+								},
+								Advice: "advice 3\nadvice 3a",
+							},
+							{
+								Severity: "warning",
+								Message: "message 4",
+								StackTrace: []messages.StackEntry{
+									{
+											FileName: "mint1.yml",
+											Line:     7,
+											Column:   9,
+									},
+								},
+							},
+						},
+					}, nil
+				}
+			})
+
+			Context("using oneline output", func() {
+				BeforeEach(func() {
+					lintConfig.OutputFormat = cli.LintOutputOneLine
+				})
+
+				It("lists only files", func() {
+					_, err := service.Lint(lintConfig)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(stdout.String()).To(Equal(`error   mint1.yml:11:22 - message 1 message 1a
+error   mint1.yml:5:22 - message 2 message 2a
+warning mint1.yml:2:6 - message 3
+warning mint1.yml:7:9 - message 4
+`))
+				})
+			})
+
+			Context("using multiline output", func() {
+				BeforeEach(func() {
+					lintConfig.OutputFormat = cli.LintOutputMultiLine
+				})
+
+				It("lists all the data from the problem", func() {
+					_, err := service.Lint(lintConfig)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(stdout.String()).To(Equal(`
+[error] message 1
+message 1a
+  4 |     run: echo hi
+> 5 |     bad: true
+    |     ^
+  6 |     env:
+  7 |       A:
+  at mint1.yml:11:22
+advice 1
+advice 1a
+
+[error] message 2
+message 2a
+  at mint1.yml:5:22
+  at *alias (mint1.yml:22:11)
+
+[warning] message 3
+  at mint1.yml:2:6
+advice 3
+advice 3a
+
+[warning] message 4
+  at mint1.yml:7:9
 
 Checked 2 files and found 4 problems.
 `))

--- a/internal/messages/messages.go
+++ b/internal/messages/messages.go
@@ -1,0 +1,45 @@
+package messages
+
+import (
+	"fmt"
+	"strings"
+)
+
+type StackEntry struct {
+	FileName string `json:"file_name"`
+	Line     int    `json:"line"`
+	Column   int    `json:"column"`
+	Name     string `json:"name"`
+}
+
+func FormatUserMessage(message string, frame string, stackTrace []StackEntry, advice string) string {
+	var builder strings.Builder
+
+	if (message != "") {
+		builder.WriteString(message)
+	}
+
+	if (frame != "") {
+		builder.WriteString("\n")
+		builder.WriteString(frame)
+	}
+
+	if (len(stackTrace) > 0) {
+		for i := len(stackTrace) - 1; i >= 0; i-- {
+			stackEntry := stackTrace[i]
+			builder.WriteString("\n")
+			if (stackEntry.Name != "") {
+				builder.WriteString(fmt.Sprintf("  at %s (%s:%d:%d)", stackEntry.Name, stackEntry.FileName, stackEntry.Line, stackEntry.Column))
+			} else {
+				builder.WriteString(fmt.Sprintf("  at %s:%d:%d", stackEntry.FileName, stackEntry.Line, stackEntry.Column))
+			}
+		}
+	}
+
+	if (advice != "") {
+		builder.WriteString("\n")
+		builder.WriteString(advice)
+	}
+
+	return builder.String()
+}

--- a/internal/messages/messages_suite_test.go
+++ b/internal/messages/messages_suite_test.go
@@ -1,0 +1,13 @@
+package messages_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestCli(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Messages Suite")
+}

--- a/internal/messages/messages_test.go
+++ b/internal/messages/messages_test.go
@@ -1,0 +1,34 @@
+package messages_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	messages "github.com/rwx-research/mint-cli/internal/messages"
+)
+
+var _ = Describe("FormatUserMessage", func() {
+	It("builds a string based on the available data", func() {
+		Expect(messages.FormatUserMessage("message", "", []messages.StackEntry{}, "")).To(Equal("message"))
+		Expect(messages.FormatUserMessage("message", "frame", []messages.StackEntry{}, "")).To(Equal("message\nframe"))
+		Expect(messages.FormatUserMessage("message", "frame", []messages.StackEntry{}, "advice")).To(Equal("message\nframe\nadvice"))
+
+		stackTrace := []messages.StackEntry{
+			{
+					FileName: "mint1.yml",
+					Line:     22,
+					Column:   11,
+					Name:     "*alias",
+			},
+			{
+					FileName: "mint1.yml",
+					Line:     5,
+					Column:   22,
+			},
+		}
+		Expect(messages.FormatUserMessage("message", "frame", stackTrace, "advice")).To(Equal(`message
+frame
+  at mint1.yml:5:22
+  at *alias (mint1.yml:22:11)
+advice`))
+	})
+})


### PR DESCRIPTION
This makes the CLI aware of stack traces and frames, and it now constructs errors and warnings using those when it can. While I was in here, I made the multiline lint format match the same format as what is printed for `mint run`. The single line format remains unchanged. This also is fully backwards compatible.