### PR TITLE
Recursively send the entire mint directory contents, not just the first level of yaml

### DIFF
--- a/internal/api/client_test.go
+++ b/internal/api/client_test.go
@@ -43,8 +43,8 @@ var _ = Describe("API Client", func() {
 
 			initRunConfig := api.InitiateRunConfig{
 				InitializationParameters: []api.InitializationParameter{},
-				TaskDefinitions: []api.TaskDefinition{
-					{Path: "foo", FileContents: "echo 'bar'"},
+				TaskDefinitions: []api.MintDirectoryEntry{
+					{Path: "foo", FileContents: "echo 'bar'", Permissions: 0o644, Type: "file"},
 				},
 				TargetedTaskKeys: []string{},
 				UseCache:         false,
@@ -82,8 +82,8 @@ var _ = Describe("API Client", func() {
 
 			initRunConfig := api.InitiateRunConfig{
 				InitializationParameters: []api.InitializationParameter{},
-				TaskDefinitions: []api.TaskDefinition{
-					{Path: "foo", FileContents: "echo 'bar'"},
+				TaskDefinitions: []api.MintDirectoryEntry{
+					{Path: "foo", FileContents: "echo 'bar'", Permissions: 0o644, Type: "file"},
 				},
 				TargetedTaskKeys: []string{},
 				UseCache:         false,
@@ -191,7 +191,7 @@ var _ = Describe("API Client", func() {
 		It("makes the request", func() {
 			body := api.SetSecretsInVaultConfig{
 				VaultName: "default",
-				Secrets: []api.Secret{{Name: "ABC", Secret: "123"}},
+				Secrets:   []api.Secret{{Name: "ABC", Secret: "123"}},
 			}
 			bodyBytes, _ := json.Marshal(body)
 

--- a/internal/api/config.go
+++ b/internal/api/config.go
@@ -27,7 +27,7 @@ func (c Config) Validate() error {
 type InitiateRunConfig struct {
 	InitializationParameters []InitializationParameter `json:"initialization_parameters"`
 	TaskDefinitions          []TaskDefinition          `json:"task_definitions"`
-	MintDirectory            []TaskDefinition          `json:"mint_directory"`
+	MintDirectory            []MintDirectoryEntry      `json:"mint_directory"`
 	TargetedTaskKeys         []string                  `json:"targeted_task_keys,omitempty"`
 	Title                    string                    `json:"title,omitempty"`
 	UseCache                 bool                      `json:"use_cache"`
@@ -86,8 +86,8 @@ func (lf LintProblem) FileLocation() string {
 	line := lf.Line
 	column := lf.Column
 
-	if (len(lf.StackTrace) > 0) {
-		lastStackEntry := lf.StackTrace[len(lf.StackTrace) - 1]
+	if len(lf.StackTrace) > 0 {
+		lastStackEntry := lf.StackTrace[len(lf.StackTrace)-1]
 		fileName = lastStackEntry.FileName
 		line = NullInt{
 			Value:  lastStackEntry.Line,

--- a/internal/api/config.go
+++ b/internal/api/config.go
@@ -26,7 +26,7 @@ func (c Config) Validate() error {
 
 type InitiateRunConfig struct {
 	InitializationParameters []InitializationParameter `json:"initialization_parameters"`
-	TaskDefinitions          []TaskDefinition          `json:"task_definitions"`
+	TaskDefinitions          []MintDirectoryEntry      `json:"task_definitions"`
 	MintDirectory            []MintDirectoryEntry      `json:"mint_directory"`
 	TargetedTaskKeys         []string                  `json:"targeted_task_keys,omitempty"`
 	Title                    string                    `json:"title,omitempty"`

--- a/internal/api/mint_directory_entry.go
+++ b/internal/api/mint_directory_entry.go
@@ -1,0 +1,9 @@
+package api
+
+type MintDirectoryEntry struct {
+	OriginalPath string `json:"-"`
+	Path         string `json:"path"`
+	Type         string `json:"type"`
+	Permissions  uint32 `json:"permissions"`
+	FileContents string `json:"file_contents"`
+}

--- a/internal/cli/service.go
+++ b/internal/cli/service.go
@@ -648,6 +648,7 @@ func (s Service) taskDefinitionsFromPaths(paths []string) ([]api.TaskDefinition,
 
 func (s Service) mintDirectoryEntries(dir string) ([]api.MintDirectoryEntry, error) {
 	mintDirectoryEntries := make([]api.MintDirectoryEntry, 0)
+	contentLength := 0
 
 	err := filepath.Walk(dir, func(pathInDir string, info os.FileInfo, err error) error {
 		if err != nil {
@@ -688,6 +689,7 @@ func (s Service) mintDirectoryEntries(dir string) ([]api.MintDirectoryEntry, err
 				return fmt.Errorf("unable to read file %q: %w", pathInDir, err)
 			}
 
+			contentLength += len(contents)
 			fileContents = string(contents)
 		}
 
@@ -708,6 +710,9 @@ func (s Service) mintDirectoryEntries(dir string) ([]api.MintDirectoryEntry, err
 	})
 	if err != nil {
 		return nil, fmt.Errorf("unable to retrieve the entire contents of the .mint directory %q: %w", dir, err)
+	}
+	if contentLength > 5*1024*1024 {
+		return nil, fmt.Errorf("the size of the .mint directory at %q exceeds 5MiB", dir)
 	}
 
 	return mintDirectoryEntries, nil

--- a/internal/cli/service_test.go
+++ b/internal/cli/service_test.go
@@ -82,13 +82,12 @@ var _ = Describe("CLI Service", func() {
 				var originalSpecifiedFileContent string
 				var originalMintDirFileContent string
 				var receivedSpecifiedFileContent string
-				var receivedMintDirFileContent string
+				var receivedMintDir []api.MintDirectoryEntry
 
 				BeforeEach(func() {
 					originalSpecifiedFileContent = "tasks:\n  - key: foo\n    run: echo 'bar'\n"
 					originalMintDirFileContent = "tasks:\n  - key: mintdir\n    run: echo 'mintdir'\n"
 					receivedSpecifiedFileContent = ""
-					receivedMintDirFileContent = ""
 
 					var err error
 
@@ -118,11 +117,13 @@ var _ = Describe("CLI Service", func() {
 					mockAPI.MockInitiateRun = func(cfg api.InitiateRunConfig) (*api.InitiateRunResult, error) {
 						Expect(cfg.TaskDefinitions).To(HaveLen(1))
 						Expect(cfg.TaskDefinitions[0].Path).To(Equal(runConfig.MintFilePath))
-						Expect(cfg.MintDirectory).To(HaveLen(1))
-						Expect(cfg.MintDirectory[0].Path).To(Equal(".mint/mintdir-tasks.yml"))
+						Expect(cfg.MintDirectory).To(HaveLen(3))
+						Expect(cfg.MintDirectory[0].Path).To(Equal(".mint"))
+						Expect(cfg.MintDirectory[1].Path).To(Equal(".mint/mintdir-tasks.json"))
+						Expect(cfg.MintDirectory[2].Path).To(Equal(".mint/mintdir-tasks.yml"))
 						Expect(cfg.UseCache).To(BeTrue())
 						receivedSpecifiedFileContent = cfg.TaskDefinitions[0].FileContents
-						receivedMintDirFileContent = cfg.MintDirectory[0].FileContents
+						receivedMintDir = cfg.MintDirectory
 						return &api.InitiateRunResult{
 							RunId:            "785ce4e8-17b9-4c8b-8869-a55e95adffe7",
 							RunURL:           "https://cloud.rwx.com/mint/rwx/runs/785ce4e8-17b9-4c8b-8869-a55e95adffe7",
@@ -139,7 +140,10 @@ var _ = Describe("CLI Service", func() {
 
 				It("sends the file contents to cloud", func() {
 					Expect(receivedSpecifiedFileContent).To(Equal(originalSpecifiedFileContent))
-					Expect(receivedMintDirFileContent).To(Equal(originalMintDirFileContent))
+					Expect(receivedMintDir).NotTo(BeNil())
+					Expect(receivedMintDir[0].FileContents).To(Equal(""))
+					Expect(receivedMintDir[1].FileContents).To(Equal("some json"))
+					Expect(receivedMintDir[2].FileContents).To(Equal(originalMintDirFileContent))
 				})
 			})
 
@@ -173,7 +177,8 @@ var _ = Describe("CLI Service", func() {
 					mockAPI.MockInitiateRun = func(cfg api.InitiateRunConfig) (*api.InitiateRunResult, error) {
 						Expect(cfg.TaskDefinitions).To(HaveLen(1))
 						Expect(cfg.TaskDefinitions[0].Path).To(Equal(runConfig.MintFilePath))
-						Expect(cfg.MintDirectory).To(HaveLen(0))
+						Expect(cfg.MintDirectory).To(HaveLen(1))
+						Expect(cfg.MintDirectory[0].Path).To(Equal(".mint"))
 						Expect(cfg.UseCache).To(BeTrue())
 						receivedSpecifiedFileContent = cfg.TaskDefinitions[0].FileContents
 						return &api.InitiateRunResult{
@@ -262,13 +267,12 @@ var _ = Describe("CLI Service", func() {
 				var originalSpecifiedFileContent string
 				var originalMintDirFileContent string
 				var receivedSpecifiedFileContent string
-				var receivedMintDirFileContent string
+				var receivedMintDir []api.MintDirectoryEntry
 
 				BeforeEach(func() {
 					originalSpecifiedFileContent = "tasks:\n  - key: foo\n    run: echo 'bar'\n"
 					originalMintDirFileContent = "tasks:\n  - key: mintdir\n    run: echo 'mintdir'\n"
 					receivedSpecifiedFileContent = ""
-					receivedMintDirFileContent = ""
 
 					var err error
 
@@ -299,11 +303,13 @@ var _ = Describe("CLI Service", func() {
 					mockAPI.MockInitiateRun = func(cfg api.InitiateRunConfig) (*api.InitiateRunResult, error) {
 						Expect(cfg.TaskDefinitions).To(HaveLen(1))
 						Expect(cfg.TaskDefinitions[0].Path).To(Equal(runConfig.MintFilePath))
-						Expect(cfg.MintDirectory).To(HaveLen(1))
-						Expect(cfg.MintDirectory[0].Path).To(Equal(".mint/mintdir-tasks.yml"))
+						Expect(cfg.MintDirectory).To(HaveLen(3))
+						Expect(cfg.MintDirectory[0].Path).To(Equal(".mint"))
+						Expect(cfg.MintDirectory[1].Path).To(Equal(".mint/mintdir-tasks.json"))
+						Expect(cfg.MintDirectory[2].Path).To(Equal(".mint/mintdir-tasks.yml"))
 						Expect(cfg.UseCache).To(BeTrue())
 						receivedSpecifiedFileContent = cfg.TaskDefinitions[0].FileContents
-						receivedMintDirFileContent = cfg.MintDirectory[0].FileContents
+						receivedMintDir = cfg.MintDirectory
 						return &api.InitiateRunResult{
 							RunId:            "785ce4e8-17b9-4c8b-8869-a55e95adffe7",
 							RunURL:           "https://cloud.rwx.com/mint/rwx/runs/785ce4e8-17b9-4c8b-8869-a55e95adffe7",
@@ -320,7 +326,10 @@ var _ = Describe("CLI Service", func() {
 
 				It("sends the file contents to cloud", func() {
 					Expect(receivedSpecifiedFileContent).To(Equal(originalSpecifiedFileContent))
-					Expect(receivedMintDirFileContent).To(Equal(originalMintDirFileContent))
+					Expect(receivedMintDir).NotTo(BeNil())
+					Expect(receivedMintDir[0].FileContents).To(Equal(""))
+					Expect(receivedMintDir[1].FileContents).To(Equal("some json"))
+					Expect(receivedMintDir[2].FileContents).To(Equal(originalMintDirFileContent))
 				})
 			})
 
@@ -355,7 +364,8 @@ var _ = Describe("CLI Service", func() {
 					mockAPI.MockInitiateRun = func(cfg api.InitiateRunConfig) (*api.InitiateRunResult, error) {
 						Expect(cfg.TaskDefinitions).To(HaveLen(1))
 						Expect(cfg.TaskDefinitions[0].Path).To(Equal(runConfig.MintFilePath))
-						Expect(cfg.MintDirectory).To(HaveLen(0))
+						Expect(cfg.MintDirectory).To(HaveLen(1))
+						Expect(cfg.MintDirectory[0].Path).To(Equal(".mint"))
 						Expect(cfg.UseCache).To(BeTrue())
 						receivedSpecifiedFileContent = cfg.TaskDefinitions[0].FileContents
 						return &api.InitiateRunResult{


### PR DESCRIPTION
With this change, we'll send the entire structure of the `.mint` directory to cloud along with all file contents. We _won't_ do anything other than track the path/type/permissions for things that are not files (no following symlinks or trying to replicate devices/sockets/etc)