### PR TITLE
Output message when not running the latest CLI version.

### DIFF
--- a/cmd/mint/leaves.go
+++ b/cmd/mint/leaves.go
@@ -1,8 +1,6 @@
 package main
 
 import (
-	"os"
-
 	"github.com/rwx-research/mint-cli/internal/cli"
 	"github.com/spf13/cobra"
 )
@@ -27,8 +25,6 @@ var (
 				Files:                    args,
 				DefaultDir:               ".mint",
 				ReplacementVersionPicker: replacementVersionPicker,
-				Stdout:                   os.Stdout,
-				Stderr:                   os.Stderr,
 			})
 		},
 		Short: "Update all leaves to their latest (minor) version",

--- a/cmd/mint/lint.go
+++ b/cmd/mint/lint.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"errors"
-	"os"
 	"slices"
 
 	"github.com/rwx-research/mint-cli/internal/api"
@@ -31,7 +30,6 @@ var (
 			lintConfig, err := cli.NewLintConfig(
 				targetedFiles,
 				LintMintDirectory,
-				os.Stdout,
 				LintOutputFormat,
 			)
 			if err != nil {

--- a/cmd/mint/login.go
+++ b/cmd/mint/login.go
@@ -50,7 +50,6 @@ var (
 				cli.LoginConfig{
 					DeviceName:         DeviceName,
 					AccessTokenBackend: accessTokenBackend,
-					Stdout:             os.Stdout,
 					OpenUrl:            openUrl,
 				},
 			)

--- a/cmd/mint/root.go
+++ b/cmd/mint/root.go
@@ -41,7 +41,7 @@ var (
 				return errors.Wrap(err, "unable to initialize API client")
 			}
 
-			service, err = cli.NewService(cli.Config{APIClient: c, SSHClient: new(ssh.Client)})
+			service, err = cli.NewService(cli.Config{APIClient: c, SSHClient: new(ssh.Client), Stdout: os.Stdout, Stderr: os.Stderr})
 			if err != nil {
 				return errors.Wrap(err, "unable to initialize CLI")
 			}

--- a/cmd/mint/vaults.go
+++ b/cmd/mint/vaults.go
@@ -8,13 +8,13 @@ import (
 )
 
 var vaultsCmd = &cobra.Command{
- 	Short: "Manage Mint vaults and secrets",
+	Short: "Manage Mint vaults and secrets",
 	Use:   "vaults",
 }
 
 var (
 	Vault string
-	File    string
+	File  string
 
 	vaultsSetSecretsCmd = &cobra.Command{
 		PreRunE: func(cmd *cobra.Command, args []string) error {
@@ -27,10 +27,10 @@ var (
 			}
 
 			return service.SetSecretsInVault(cli.SetSecretsInVaultConfig{
-				Vault: Vault,
-				File: File,
+				Vault:   Vault,
+				File:    File,
 				Secrets: secrets,
-				Stdout: os.Stdout,
+				Stdout:  os.Stdout,
 			})
 		},
 		Short: "Set secrets in a vault",
@@ -41,5 +41,5 @@ var (
 func init() {
 	vaultsSetSecretsCmd.Flags().StringVar(&Vault, "vault", "default", "the name of the vault to set the secrets in")
 	vaultsSetSecretsCmd.Flags().StringVar(&File, "file", "", "the path to a file in dotenv format to read the secrets from")
-	vaultsCmd.AddCommand(vaultsSetSecretsCmd);
+	vaultsCmd.AddCommand(vaultsSetSecretsCmd)
 }

--- a/cmd/mint/vaults.go
+++ b/cmd/mint/vaults.go
@@ -1,8 +1,6 @@
 package main
 
 import (
-	"os"
-
 	"github.com/rwx-research/mint-cli/internal/cli"
 	"github.com/spf13/cobra"
 )
@@ -30,7 +28,6 @@ var (
 				Vault:   Vault,
 				File:    File,
 				Secrets: secrets,
-				Stdout:  os.Stdout,
 			})
 		},
 		Short: "Set secrets in a vault",

--- a/cmd/mint/whoami.go
+++ b/cmd/mint/whoami.go
@@ -1,8 +1,6 @@
 package main
 
 import (
-	"os"
-
 	"github.com/rwx-research/mint-cli/internal/cli"
 
 	"github.com/spf13/cobra"
@@ -16,7 +14,7 @@ var (
 			return requireAccessToken()
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			err := service.Whoami(cli.WhoamiConfig{Json: WhoamiJson, Stdout: os.Stdout})
+			err := service.Whoami(cli.WhoamiConfig{Json: WhoamiJson})
 			if err != nil {
 				return err
 			}

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.22.0
 toolchain go1.23.6
 
 require (
+	github.com/Masterminds/semver/v3 v3.3.1
 	github.com/briandowns/spinner v1.23.2
 	github.com/kopoli/go-terminal-size v0.0.0-20170219200355-5c97524c8b54
 	github.com/magefile/mage v1.15.0

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/Masterminds/semver/v3 v3.3.1 h1:QtNSWtVZ3nBfk8mAOu/B6v7FMJ+NHTIgUPi7rj+4nv4=
+github.com/Masterminds/semver/v3 v3.3.1/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lprf4nC11bSS5beM=
 github.com/briandowns/spinner v1.23.2 h1:Zc6ecUnI+YzLmJniCfDNaMbW0Wid1d5+qcTq4L2FW8w=
 github.com/briandowns/spinner v1.23.2/go.mod h1:LaZeM4wm2Ywy6vO571mvhQNRcWfRUnXOs0RcKV0wYKM=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -370,16 +370,16 @@ func (c Client) GetLeafVersions() (*LeafVersionsResult, error) {
 }
 
 type ErrorMessage struct {
-	Message    string       				 `json:"message"`
+	Message    string                `json:"message"`
 	StackTrace []messages.StackEntry `json:"stack_trace,omitempty"`
-	Frame      string       			 	 `json:"frame"`
-	Advice     string       				 `json:"advice"`
+	Frame      string                `json:"frame"`
+	Advice     string                `json:"advice"`
 }
 
 // extractErrorMessage is a small helper function for parsing an API error message
 func extractErrorMessage(reader io.Reader) string {
 	errorStruct := struct {
-		Error 				string 				 `json:"error,omitempty"`
+		Error         string         `json:"error,omitempty"`
 		ErrorMessages []ErrorMessage `json:"error_messages,omitempty"`
 	}{}
 

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -13,11 +13,18 @@ import (
 	"github.com/rwx-research/mint-cli/internal/accesstoken"
 	"github.com/rwx-research/mint-cli/internal/errors"
 	"github.com/rwx-research/mint-cli/internal/messages"
+	"github.com/rwx-research/mint-cli/internal/versions"
 )
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (rtf roundTripFunc) RoundTrip(r *http.Request) (*http.Response, error) {
+	return rtf(r)
+}
 
 // Client is an API Client for Mint
 type Client struct {
-	RoundTrip func(*http.Request) (*http.Response, error)
+	http.RoundTripper
 }
 
 func NewClient(cfg Config) (Client, error) {
@@ -45,7 +52,12 @@ func NewClient(cfg Config) (Client, error) {
 		return http.DefaultClient.Do(req)
 	}
 
-	return Client{roundTrip}, nil
+	return NewClientWithRoundTrip(roundTrip), nil
+}
+
+func NewClientWithRoundTrip(rt func(*http.Request) (*http.Response, error)) Client {
+	roundTripper := versions.NewRoundTripper(roundTripFunc(rt))
+	return Client{roundTripper}
 }
 
 func (c Client) GetDebugConnectionInfo(debugKey string) (DebugConnectionInfo, error) {

--- a/internal/api/client_test.go
+++ b/internal/api/client_test.go
@@ -37,7 +37,7 @@ var _ = Describe("API Client", func() {
 					Status:     "201 Created",
 					StatusCode: 201,
 					Body:       io.NopCloser(bytes.NewReader(bodyBytes)),
-					Header:     http.Header{"X-Mint-Cli-Latest-Version": []string{"999.888.777"}},
+					Header:     http.Header{"X-Mint-Cli-Latest-Version": []string{"1000000.0.0"}},
 				}, nil
 			}
 
@@ -57,7 +57,7 @@ var _ = Describe("API Client", func() {
 			Expect(result.RunId).To(Equal("123"))
 
 			// This works as long as this is the only test we're setting the latest version header.
-			Expect(versions.GetCliLatestVersion().String()).To(Equal("999.888.777"))
+			Expect(versions.GetCliLatestVersion().String()).To(Equal("1000000.0.0"))
 			Expect(versions.NewVersionAvailable()).To(BeTrue())
 		})
 

--- a/internal/api/client_test.go
+++ b/internal/api/client_test.go
@@ -12,6 +12,7 @@ import (
 	"net/url"
 
 	"github.com/rwx-research/mint-cli/internal/api"
+	"github.com/rwx-research/mint-cli/internal/versions"
 )
 
 var _ = Describe("API Client", func() {
@@ -36,10 +37,11 @@ var _ = Describe("API Client", func() {
 					Status:     "201 Created",
 					StatusCode: 201,
 					Body:       io.NopCloser(bytes.NewReader(bodyBytes)),
+					Header:     http.Header{"X-Mint-Cli-Latest-Version": []string{"999.888.777"}},
 				}, nil
 			}
 
-			c := api.Client{roundTrip}
+			c := api.NewClientWithRoundTrip(roundTrip)
 
 			initRunConfig := api.InitiateRunConfig{
 				InitializationParameters: []api.InitializationParameter{},
@@ -53,6 +55,10 @@ var _ = Describe("API Client", func() {
 			result, err := c.InitiateRun(initRunConfig)
 			Expect(err).To(BeNil())
 			Expect(result.RunId).To(Equal("123"))
+
+			// This works as long as this is the only test we're setting the latest version header.
+			Expect(versions.GetCliLatestVersion().String()).To(Equal("999.888.777"))
+			Expect(versions.NewVersionAvailable()).To(BeTrue())
 		})
 
 		It("prefixes the endpoint with the base path and parses snakecase responses", func() {
@@ -78,7 +84,7 @@ var _ = Describe("API Client", func() {
 				}, nil
 			}
 
-			c := api.Client{roundTrip}
+			c := api.NewClientWithRoundTrip(roundTrip)
 
 			initRunConfig := api.InitiateRunConfig{
 				InitializationParameters: []api.InitializationParameter{},
@@ -115,7 +121,7 @@ var _ = Describe("API Client", func() {
 				}, nil
 			}
 
-			c := api.Client{roundTrip}
+			c := api.NewClientWithRoundTrip(roundTrip)
 
 			obtainAuthCodeConfig := api.ObtainAuthCodeConfig{
 				Code: api.ObtainAuthCodeCode{
@@ -150,7 +156,7 @@ var _ = Describe("API Client", func() {
 				}, nil
 			}
 
-			c := api.Client{roundTrip}
+			c := api.NewClientWithRoundTrip(roundTrip)
 
 			_, err := c.AcquireToken("https://cloud.rwx.com/api/auth/codes/some-uuid/token")
 			Expect(err).To(BeNil())
@@ -180,7 +186,7 @@ var _ = Describe("API Client", func() {
 				}, nil
 			}
 
-			c := api.Client{roundTrip}
+			c := api.NewClientWithRoundTrip(roundTrip)
 
 			_, err := c.Whoami()
 			Expect(err).To(BeNil())
@@ -204,7 +210,7 @@ var _ = Describe("API Client", func() {
 				}, nil
 			}
 
-			c := api.Client{roundTrip}
+			c := api.NewClientWithRoundTrip(roundTrip)
 
 			_, err := c.SetSecretsInVault(body)
 			Expect(err).To(BeNil())

--- a/internal/api/debug_connection_info.go
+++ b/internal/api/debug_connection_info.go
@@ -7,5 +7,5 @@ type DebugConnectionInfo struct {
 }
 
 type DebugConnectionInfoError struct {
-	Error         string
+	Error string
 }

--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -11,6 +11,8 @@ import (
 type Config struct {
 	APIClient APIClient
 	SSHClient SSHClient
+	Stdout    io.Writer
+	Stderr    io.Writer
 }
 
 func (c Config) Validate() error {
@@ -20,6 +22,14 @@ func (c Config) Validate() error {
 
 	if c.SSHClient == nil {
 		return errors.New("missing SSH client constructor")
+	}
+
+	if c.Stdout == nil {
+		return errors.New("missing Stdout")
+	}
+
+	if c.Stderr == nil {
+		return errors.New("missing Stderr")
 	}
 
 	return nil
@@ -66,7 +76,6 @@ const (
 type LintConfig struct {
 	MintDirectory string
 	MintFilePaths []string
-	Output        io.Writer
 	OutputFormat  LintOutputFormat
 }
 
@@ -74,7 +83,7 @@ func (c LintConfig) Validate() error {
 	return nil
 }
 
-func NewLintConfig(filePaths []string, mintDir string, output io.Writer, formatString string) (LintConfig, error) {
+func NewLintConfig(filePaths []string, mintDir string, formatString string) (LintConfig, error) {
 	var format LintOutputFormat
 
 	switch formatString {
@@ -91,7 +100,6 @@ func NewLintConfig(filePaths []string, mintDir string, output io.Writer, formatS
 	return LintConfig{
 		MintDirectory: mintDir,
 		MintFilePaths: filePaths,
-		Output:        output,
 		OutputFormat:  format,
 	}, nil
 }
@@ -99,7 +107,6 @@ func NewLintConfig(filePaths []string, mintDir string, output io.Writer, formatS
 type LoginConfig struct {
 	DeviceName         string
 	AccessTokenBackend accesstoken.Backend
-	Stdout             io.Writer
 	OpenUrl            func(url string) error
 }
 
@@ -112,8 +119,7 @@ func (c LoginConfig) Validate() error {
 }
 
 type WhoamiConfig struct {
-	Json   bool
-	Stdout io.Writer
+	Json bool
 }
 
 func (c WhoamiConfig) Validate() error {
@@ -124,7 +130,6 @@ type SetSecretsInVaultConfig struct {
 	Secrets []string
 	Vault   string
 	File    string
-	Stdout  io.Writer
 }
 
 func (c SetSecretsInVaultConfig) Validate() error {
@@ -143,8 +148,6 @@ type UpdateLeavesConfig struct {
 	DefaultDir               string
 	Files                    []string
 	ReplacementVersionPicker func(versions api.LeafVersionsResult, leaf string, major string) (string, error)
-	Stdout                   io.Writer
-	Stderr                   io.Writer
 }
 
 func (c UpdateLeavesConfig) Validate() error {
@@ -154,14 +157,6 @@ func (c UpdateLeavesConfig) Validate() error {
 
 	if c.ReplacementVersionPicker == nil {
 		return errors.New("a replacement version picker must be provided")
-	}
-
-	if c.Stdout == nil {
-		return errors.New("a stdout interface needs to be provided")
-	}
-
-	if c.Stdout == nil {
-		return errors.New("a stderr interface needs to be provided")
 	}
 
 	return nil

--- a/internal/messages/messages.go
+++ b/internal/messages/messages.go
@@ -15,20 +15,20 @@ type StackEntry struct {
 func FormatUserMessage(message string, frame string, stackTrace []StackEntry, advice string) string {
 	var builder strings.Builder
 
-	if (message != "") {
+	if message != "" {
 		builder.WriteString(message)
 	}
 
-	if (frame != "") {
+	if frame != "" {
 		builder.WriteString("\n")
 		builder.WriteString(frame)
 	}
 
-	if (len(stackTrace) > 0) {
+	if len(stackTrace) > 0 {
 		for i := len(stackTrace) - 1; i >= 0; i-- {
 			stackEntry := stackTrace[i]
 			builder.WriteString("\n")
-			if (stackEntry.Name != "") {
+			if stackEntry.Name != "" {
 				builder.WriteString(fmt.Sprintf("  at %s (%s:%d:%d)", stackEntry.Name, stackEntry.FileName, stackEntry.Line, stackEntry.Column))
 			} else {
 				builder.WriteString(fmt.Sprintf("  at %s:%d:%d", stackEntry.FileName, stackEntry.Line, stackEntry.Column))
@@ -36,7 +36,7 @@ func FormatUserMessage(message string, frame string, stackTrace []StackEntry, ad
 		}
 	}
 
-	if (advice != "") {
+	if advice != "" {
 		builder.WriteString("\n")
 		builder.WriteString(advice)
 	}

--- a/internal/messages/messages_test.go
+++ b/internal/messages/messages_test.go
@@ -14,15 +14,15 @@ var _ = Describe("FormatUserMessage", func() {
 
 		stackTrace := []messages.StackEntry{
 			{
-					FileName: "mint1.yml",
-					Line:     22,
-					Column:   11,
-					Name:     "*alias",
+				FileName: "mint1.yml",
+				Line:     22,
+				Column:   11,
+				Name:     "*alias",
 			},
 			{
-					FileName: "mint1.yml",
-					Line:     5,
-					Column:   22,
+				FileName: "mint1.yml",
+				Line:     5,
+				Column:   22,
 			},
 		}
 		Expect(messages.FormatUserMessage("message", "frame", stackTrace, "advice")).To(Equal(`message

--- a/internal/versions/interceptor.go
+++ b/internal/versions/interceptor.go
@@ -1,0 +1,25 @@
+package versions
+
+import (
+	"net/http"
+)
+
+const latestVersionHeader = "X-Mint-Cli-Latest-Version"
+
+type versionInterceptor struct {
+	http.RoundTripper
+}
+
+func (vi versionInterceptor) RoundTrip(r *http.Request) (*http.Response, error) {
+	resp, err := vi.RoundTripper.RoundTrip(r)
+	if err == nil {
+		if lv := resp.Header.Get(latestVersionHeader); lv != "" {
+			_ = SetCliLatestVersion(lv)
+		}
+	}
+	return resp, err
+}
+
+func NewRoundTripper(rt http.RoundTripper) http.RoundTripper {
+	return versionInterceptor{RoundTripper: rt}
+}

--- a/internal/versions/versions.go
+++ b/internal/versions/versions.go
@@ -1,0 +1,58 @@
+package versions
+
+import (
+	"sync"
+
+	semver "github.com/Masterminds/semver/v3"
+	"github.com/rwx-research/mint-cli/cmd/mint/config"
+)
+
+var versionHolder *lockedVersions
+
+type lockedVersions struct {
+	currentVersion *semver.Version
+	latestVersion  *semver.Version
+	mu             sync.RWMutex
+}
+
+func init() {
+	currentVersionStr := config.Version
+	if currentVersionStr == "" {
+		currentVersionStr = "0.0.0"
+	}
+	versionHolder = &lockedVersions{
+		currentVersion: semver.MustParse(currentVersionStr),
+		latestVersion:  semver.MustParse("0.0.0"),
+	}
+}
+
+func GetCliCurrentVersion() *semver.Version {
+	return versionHolder.currentVersion
+}
+
+func GetCliLatestVersion() *semver.Version {
+	versionHolder.mu.RLock()
+	defer versionHolder.mu.RUnlock()
+
+	return versionHolder.latestVersion
+}
+
+func SetCliLatestVersion(versionStr string) error {
+	version, err := semver.NewVersion(versionStr)
+	if err != nil {
+		return err
+	}
+
+	versionHolder.mu.Lock()
+	versionHolder.latestVersion = version
+	versionHolder.mu.Unlock()
+
+	return nil
+}
+
+func NewVersionAvailable() bool {
+	currentVersion := GetCliCurrentVersion()
+	latestVersion := GetCliLatestVersion()
+
+	return latestVersion.GreaterThan(currentVersion)
+}

--- a/internal/versions/versions.go
+++ b/internal/versions/versions.go
@@ -21,7 +21,11 @@ func init() {
 	currentVersionStr := config.Version
 	if currentVersionStr == "" {
 		currentVersionStr = "0.0.0"
+	} else if strings.HasPrefix(currentVersionStr, "git-") || strings.HasPrefix(currentVersionStr, "testing-") {
+		// This is a development build, assume it is newer than any release.
+		currentVersionStr = "9999+" + currentVersionStr
 	}
+
 	versionHolder = &lockedVersions{
 		currentVersion: semver.MustParse(currentVersionStr),
 		latestVersion:  semver.MustParse("0.0.0"),

--- a/internal/versions/versions.go
+++ b/internal/versions/versions.go
@@ -1,6 +1,8 @@
 package versions
 
 import (
+	"os"
+	"strings"
 	"sync"
 
 	semver "github.com/Masterminds/semver/v3"
@@ -55,4 +57,13 @@ func NewVersionAvailable() bool {
 	latestVersion := GetCliLatestVersion()
 
 	return latestVersion.GreaterThan(currentVersion)
+}
+
+func InstalledWithHomebrew() bool {
+	fname, err := os.Executable()
+	if err != nil {
+		return false
+	}
+
+	return strings.Contains(strings.ToLower(fname), "/homebrew/")
 }


### PR DESCRIPTION
When the Mint CLI connects to Cloud, capture the latest version (if available). Compare this to the currently-running version and outputs a message to stderr:

```
========================================
A new version of Mint is available!
You are currently on version 1.0.2
The latest version is 1.3.2
========================================
```

If we believe you installed the CLI through Homebrew, we'll include instructions for upgrading:

```
========================================
A new version of Mint is available!
You are currently on version 1.0.2
The latest version is 1.3.2

You can update to the latest version with:
    brew upgrade rwx-research/tap/mint
========================================
```

These messages are output before any command output (and only to stderr). Output can be disabled by setting `MINT_HIDE_LATEST_VERSION`:

```bash
MINT_HIDE_LATEST_VERSION=1 mint lint
```