### PR TITLE
Add `--debug` flag to run command.

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,3 +1,4 @@
 golang 1.24.1
 golangci-lint 1.64.6
 mage 1.14.0
+ginkgo 2.19.0

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,3 @@
 golang 1.24.1
 golangci-lint 1.64.6
+mage 1.14.0

--- a/cmd/mint/root.go
+++ b/cmd/mint/root.go
@@ -16,7 +16,7 @@ import (
 
 var (
 	AccessToken string
-	Debug       bool
+	Verbose     bool
 
 	mintHost           string
 	service            cli.Service
@@ -59,8 +59,8 @@ func init() {
 	}
 
 	rootCmd.PersistentFlags().StringVar(&AccessToken, "access-token", os.Getenv("RWX_ACCESS_TOKEN"), "the access token for Mint")
-	rootCmd.PersistentFlags().BoolVar(&Debug, "debug", false, "enable debug output")
-	_ = rootCmd.PersistentFlags().MarkHidden("debug")
+	rootCmd.PersistentFlags().BoolVar(&Verbose, "verbose", false, "enable debug output")
+	_ = rootCmd.PersistentFlags().MarkHidden("verbose")
 
 	rootCmd.AddCommand(runCmd)
 	rootCmd.AddCommand(debugCmd)

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -85,7 +85,7 @@ func (c Client) GetDebugConnectionInfo(debugKey string) (DebugConnectionInfo, er
 	case 400:
 		connectionError := DebugConnectionInfoError{}
 		if err := json.NewDecoder(resp.Body).Decode(&connectionError); err == nil {
-			return connectionInfo, errors.New(connectionError.Error)
+			return connectionInfo, errors.Wrap(errors.ErrBadRequest, connectionError.Error)
 		}
 		return connectionInfo, errors.ErrBadRequest
 	case 404:
@@ -93,9 +93,11 @@ func (c Client) GetDebugConnectionInfo(debugKey string) (DebugConnectionInfo, er
 	case 410:
 		connectionError := DebugConnectionInfoError{}
 		if err := json.NewDecoder(resp.Body).Decode(&connectionError); err == nil {
-			return connectionInfo, errors.New(connectionError.Error)
+			return connectionInfo, errors.Wrap(errors.ErrGone, connectionError.Error)
 		}
 		return connectionInfo, errors.ErrGone
+	case 503:
+		return connectionInfo, errors.ErrRetry
 	default:
 		return connectionInfo, errors.New(fmt.Sprintf("Unable to call Mint API - %s", resp.Status))
 	}

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -96,8 +96,6 @@ func (c Client) GetDebugConnectionInfo(debugKey string) (DebugConnectionInfo, er
 			return connectionInfo, errors.Wrap(errors.ErrGone, connectionError.Error)
 		}
 		return connectionInfo, errors.ErrGone
-	case 503:
-		return connectionInfo, errors.ErrRetry
 	default:
 		return connectionInfo, errors.New(fmt.Sprintf("Unable to call Mint API - %s", resp.Status))
 	}

--- a/internal/api/debug_connection_info.go
+++ b/internal/api/debug_connection_info.go
@@ -1,6 +1,7 @@
 package api
 
 type DebugConnectionInfo struct {
+	Debuggable     bool
 	Address        string
 	PublicHostKey  string `json:"public_host_key"`
 	PrivateUserKey string `json:"private_user_key"`

--- a/internal/cli/service.go
+++ b/internal/cli/service.go
@@ -49,6 +49,10 @@ func (s Service) DebugTask(cfg DebugTaskConfig) error {
 		return err
 	}
 
+	if !connectionInfo.Debuggable {
+		return errors.Wrap(errors.ErrRetry, "The task or run is not in a debuggable state")
+	}
+
 	privateUserKey, err := ssh.ParsePrivateKey([]byte(connectionInfo.PrivateUserKey))
 	if err != nil {
 		return errors.Wrapf(err, "unable to parse key material retrieved from Cloud API")

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -11,6 +11,7 @@ var (
 	ErrBadRequest    = errors.New("bad request")
 	ErrNotFound      = errors.New("not found")
 	ErrGone          = errors.New("gone")
+	ErrRetry         = errors.New("retry")
 
 	As        = errors.As
 	Errorf    = errors.Errorf


### PR DESCRIPTION
This will automatically connect to a debug session in case a breakpoint is hit.

**Note the following  breaking change:** We previously already had `--debug` flag defined, which made log output more verbose. This flag has been renamed to `--verbose`. Luckily, the flag was previously hidden (i.e. it was not documented in the help text, nor our documentation), so I feel confident that we can release this feature without bumping the major version number.