### PR TITLE
On `mint run`, add a `base` configuration if missing

### DIFF
--- a/internal/cli/service_test.go
+++ b/internal/cli/service_test.go
@@ -1766,6 +1766,34 @@ AAAEC6442PQKevgYgeT0SIu9zwlnEMl6MF59ZgM+i0ByMv4eLJPqG3xnZcEQmktHj/GY2i
 			})
 		})
 
+		Context("when yaml file is actually json", func() {
+			var mintDir string
+
+			BeforeEach(func() {
+				var err error
+
+				mintDir = tmp
+
+				err = os.WriteFile(filepath.Join(mintDir, "bar.yaml"), []byte(`{
+"tasks": [
+  { "key": "a" },
+  { "key": "b" }
+]
+}`), 0o644)
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			It("ignores the file", func() {
+				err := service.ResolveBase(cli.ResolveBaseConfig{
+					DefaultDir: mintDir,
+				})
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(mockStderr.String()).To(Equal(""))
+				Expect(mockStdout.String()).To(ContainSubstring("No run files found"))
+			})
+		})
+
 		Context("when yaml file doesn't include base", func() {
 			var mintDir string
 

--- a/internal/cli/service_test.go
+++ b/internal/cli/service_test.go
@@ -336,7 +336,7 @@ var _ = Describe("CLI Service", func() {
 				})
 
 				It("prints a warning", func() {
-					Expect(mockStderr.String()).To(ContainSubstring("WARNING: The file at \"mint.yml\" has been modified to include a \"base\" block. This block will be required in the future.\nFor more information, see the documentation at https://www.rwx.com/docs/mint/base\n"))
+					Expect(mockStderr.String()).To(ContainSubstring("WARNING: The file at \"mint.yml\" has been modified to include a \"base\" field. This field will be required in the future.\nFor more information, see the documentation at https://www.rwx.com/docs/mint/base\n"))
 				})
 			})
 		})

--- a/internal/cli/service_test.go
+++ b/internal/cli/service_test.go
@@ -336,7 +336,7 @@ var _ = Describe("CLI Service", func() {
 				})
 
 				It("prints a warning", func() {
-					Expect(mockStderr.String()).To(ContainSubstring("WARNING: The file at \"mint.yml\" has been modified to include a \"base\" field. This field will be required in the future.\nFor more information, see the documentation at https://www.rwx.com/docs/mint/base\n"))
+					Expect(mockStderr.String()).To(ContainSubstring("Configured \"mint.yml\" to run on ubuntu 24.04\n"))
 				})
 			})
 		})


### PR DESCRIPTION
When initiating a CLI run via `mint run`, the target file is checked for a `base` configuration.

If the `base` is missing (or incomplete), automatically inject the missing configuration and save the run definition file. When this happens, a warning is output.

If `base` is already configured, the file is not changed and no server-side resolution is requested.

This message will be output to stderr ahead of the "run is watchable":

> Configured "../mint-defs/task.yml" to run on ubuntu 24.04
>
> Run is watchable at https://cloud.rwx.com/mint/rwx/runs/48e65c10216c40b187426479505f096c