### PR TITLE
Reload updated files from Mint directory when base is added on run.

### DIFF
--- a/internal/cli/service.go
+++ b/internal/cli/service.go
@@ -733,7 +733,6 @@ type baseLayerRunFile struct {
 type resolveBaseResult struct {
 	ErroredRunFiles []baseLayerRunFile
 	UpdatedRunFiles []baseLayerRunFile
-	NoRunFilesFound bool
 }
 
 func (r resolveBaseResult) HasChanges() bool {
@@ -778,7 +777,7 @@ func (s Service) ResolveBase(cfg ResolveBaseConfig) error {
 		return fmt.Sprintf("%d files", len(files))
 	}
 
-	if result.NoRunFilesFound {
+	if len(yamlFiles) == 0 {
 		fmt.Fprintf(s.Stdout, "No run files found in %q.\n", cfg.DefaultDir)
 	} else if !result.HasChanges() {
 		fmt.Fprintln(s.Stdout, "No run files needed to be updated.")
@@ -838,7 +837,7 @@ func (s Service) resolveBaseForFiles(mintFiles []api.MintDirectoryEntry, request
 	}
 
 	if len(runFiles) == 0 {
-		return resolveBaseResult{NoRunFilesFound: true}, nil
+		return resolveBaseResult{}, nil
 	}
 
 	specToResolved, err := s.resolveBaseSpecs(runFiles)
@@ -869,7 +868,6 @@ func (s Service) resolveBaseForFiles(mintFiles []api.MintDirectoryEntry, request
 	return resolveBaseResult{
 		ErroredRunFiles: erroredRunFiles,
 		UpdatedRunFiles: updatedRunFiles,
-		NoRunFilesFound: len(runFiles) == 0,
 	}, nil
 }
 

--- a/internal/cli/service.go
+++ b/internal/cli/service.go
@@ -167,7 +167,15 @@ func (s Service) InitiateRun(cfg InitiateRunConfig) (*api.InitiateRunResult, err
 		// Reload run definitions after modifying the file
 		taskDefinitions, err = s.mintDirectoryEntriesFromPaths([]string{taskDefinitionYamlPath})
 		if err != nil {
-			return nil, errors.Wrap(err, "unable to read provided files")
+			return nil, errors.Wrapf(err, "unable to reload %q", taskDefinitionYamlPath)
+		}
+		if mintDirectoryPath != "" {
+			mintDirectoryEntries, err := s.mintDirectoryEntries(mintDirectoryPath)
+			if err != nil && !errors.Is(err, errors.ErrFileNotExists) {
+				return nil, errors.Wrapf(err, "unable to reload mint directory %q", mintDirectoryPath)
+			}
+
+			mintDirectory = mintDirectoryEntries
 		}
 	}
 
@@ -416,7 +424,6 @@ func outputLintOneLine(w io.Writer, lintedFiles []api.LintProblem) error {
 	return nil
 }
 
-// InitiateRun will connect to the Cloud API and start a new run in Mint.
 func (s Service) Login(cfg LoginConfig) error {
 	err := cfg.Validate()
 	if err != nil {

--- a/internal/cli/service_test.go
+++ b/internal/cli/service_test.go
@@ -1790,7 +1790,7 @@ AAAEC6442PQKevgYgeT0SIu9zwlnEMl6MF59ZgM+i0ByMv4eLJPqG3xnZcEQmktHj/GY2i
 
 				Expect(err).NotTo(HaveOccurred())
 				Expect(mockStderr.String()).To(Equal(""))
-				Expect(mockStdout.String()).To(ContainSubstring("No run files found"))
+				Expect(mockStdout.String()).To(ContainSubstring("No run files needed to be updated"))
 			})
 		})
 

--- a/internal/cli/service_test.go
+++ b/internal/cli/service_test.go
@@ -288,36 +288,36 @@ var _ = Describe("CLI Service", func() {
 			Context("when 'base' is missing", func() {
 				var originalSpecifiedFileContent string
 				var receivedSpecifiedFileContent string
+				var receivedMintDirectoryFileContent string
 
 				BeforeEach(func() {
 					originalSpecifiedFileContent = "tasks:\n  - key: foo\n    run: echo 'bar'\n"
 
 					var err error
 
-					workingDir := filepath.Join(tmp, "some", "path", "to", "working", "directory")
-					err = os.MkdirAll(workingDir, 0o755)
+					mintDir := filepath.Join(tmp, ".mint")
+					err = os.MkdirAll(mintDir, 0o755)
 					Expect(err).NotTo(HaveOccurred())
 
-					err = os.Chdir(workingDir)
+					err = os.WriteFile(filepath.Join(mintDir, "foo.yml"), []byte(originalSpecifiedFileContent), 0o644)
 					Expect(err).NotTo(HaveOccurred())
 
-					err = os.WriteFile(filepath.Join(workingDir, "mint.yml"), []byte(originalSpecifiedFileContent), 0o644)
-					Expect(err).NotTo(HaveOccurred())
-
-					runConfig.MintFilePath = "mint.yml"
-					runConfig.MintDirectory = ""
+					runConfig.MintFilePath = ".mint/foo.yml"
+					runConfig.MintDirectory = ".mint"
 
 					mockAPI.MockInitiateRun = func(cfg api.InitiateRunConfig) (*api.InitiateRunResult, error) {
 						Expect(cfg.TaskDefinitions).To(HaveLen(1))
 						Expect(cfg.TaskDefinitions[0].Path).To(Equal(runConfig.MintFilePath))
-						Expect(cfg.MintDirectory).To(HaveLen(0))
+						Expect(cfg.MintDirectory).To(HaveLen(2))
 						Expect(cfg.UseCache).To(BeTrue())
 						receivedSpecifiedFileContent = cfg.TaskDefinitions[0].FileContents
+						receivedMintDirectoryFileContent = cfg.MintDirectory[1].FileContents
+
 						return &api.InitiateRunResult{
 							RunId:            "785ce4e8-17b9-4c8b-8869-a55e95adffe7",
 							RunURL:           "https://cloud.rwx.com/mint/rwx/runs/785ce4e8-17b9-4c8b-8869-a55e95adffe7",
 							TargetedTaskKeys: []string{},
-							DefinitionPath:   ".mint/mint.yml",
+							DefinitionPath:   ".mint/foo.yml",
 						}, nil
 					}
 				})
@@ -335,8 +335,12 @@ var _ = Describe("CLI Service", func() {
 					Expect(receivedSpecifiedFileContent).To(Equal(fmt.Sprintf("%s\n%s", baseSpec, originalSpecifiedFileContent)))
 				})
 
+				It("passes the updated file content in the mint directory artifact", func() {
+					Expect(receivedMintDirectoryFileContent).To(Equal(fmt.Sprintf("%s\n%s", baseSpec, originalSpecifiedFileContent)))
+				})
+
 				It("prints a warning", func() {
-					Expect(mockStderr.String()).To(ContainSubstring("Configured \"mint.yml\" to run on ubuntu 24.04\n"))
+					Expect(mockStderr.String()).To(ContainSubstring("Configured \".mint/foo.yml\" to run on ubuntu 24.04\n"))
 				})
 			})
 		})


### PR DESCRIPTION
Fixes a bug that prevented updated file content from being reflected in Mint directory artifacts after `base` was added to a run definition in the `.mint` directory.

Also fixes a message from `mint resolve base` when all run definitions already have `base` defined.