### PR TITLE
Add `mint update base` and refactor YAML file handling.

### DIFF
--- a/cmd/mint/dispatch.go
+++ b/cmd/mint/dispatch.go
@@ -15,12 +15,12 @@ import (
 )
 
 var (
-	DispatchParams    []string
-	DispatchJson      bool
-	DispatchOpen      bool
-	DispatchDebug     bool
-	DispatchTitle     string
-	DispatchRef       string
+	DispatchParams []string
+	DispatchJson   bool
+	DispatchOpen   bool
+	DispatchDebug  bool
+	DispatchTitle  string
+	DispatchRef    string
 
 	dispatchCmd = &cobra.Command{
 		Args: cobra.ExactArgs(1),

--- a/cmd/mint/leaves.go
+++ b/cmd/mint/leaves.go
@@ -22,7 +22,7 @@ var (
 
 			return service.UpdateLeaves(cli.UpdateLeavesConfig{
 				Files:                    args,
-				DefaultDir:               ".mint",
+				MintDirectory:            MintDirectory,
 				ReplacementVersionPicker: replacementVersionPicker,
 			})
 		},
@@ -35,5 +35,6 @@ var (
 
 func init() {
 	leavesUpdateCmd.Flags().BoolVar(&LeavesAllowMajorVersionChange, "allow-major-version-change", false, "update leaves to the latest major version")
+	addMintDirFlag(leavesUpdateCmd)
 	leavesCmd.AddCommand(leavesUpdateCmd)
 }

--- a/cmd/mint/resolve.go
+++ b/cmd/mint/resolve.go
@@ -59,8 +59,8 @@ var (
 
 func resolveBase(files []string) error {
 	base, err := service.ResolveBase(cli.ResolveBaseConfig{
-		DefaultDir: ".mint",
-		Files:      files,
+		Files:         files,
+		MintDirectory: MintDirectory,
 	})
 	if err != nil {
 		return err
@@ -73,8 +73,8 @@ func resolveBase(files []string) error {
 
 func resolveLeaves(files []string) error {
 	_, err := service.ResolveLeaves(cli.ResolveLeavesConfig{
-		DefaultDir:          ".mint",
 		Files:               files,
+		MintDirectory:       MintDirectory,
 		LatestVersionPicker: cli.PickLatestMajorVersion,
 	})
 	return err
@@ -84,6 +84,11 @@ func init() {
 	resolveBaseCmd.Flags().StringVar(&resolveBaseOs, "os", "", "target operating system")
 	resolveBaseCmd.Flags().StringVar(&resolveBaseTag, "tag", "", "target base layer tag")
 	resolveBaseCmd.Flags().StringVar(&resolveBaseArch, "arch", "", "target architecture")
+	addMintDirFlag(resolveBaseCmd)
+
+	addMintDirFlag(resolveLeavesCmd)
+
 	resolveCmd.AddCommand(resolveBaseCmd)
 	resolveCmd.AddCommand(resolveLeavesCmd)
+	addMintDirFlag(resolveCmd)
 }

--- a/cmd/mint/root.go
+++ b/cmd/mint/root.go
@@ -51,6 +51,10 @@ var (
 	}
 )
 
+func addMintDirFlag(cmd *cobra.Command) {
+	cmd.Flags().StringVarP(&MintDirectory, "dir", "d", "", "the directory your Mint files are located in, typically `.mint`. By default, the CLI traverses up until it finds a `.mint` directory.")
+}
+
 func init() {
 	// A different host can only be set over the environment
 	mintHost = os.Getenv("MINT_HOST")

--- a/cmd/mint/run.go
+++ b/cmd/mint/run.go
@@ -131,7 +131,7 @@ func init() {
 	runCmd.Flags().BoolVar(&NoCache, "no-cache", false, "do not read or write to the cache")
 	runCmd.Flags().StringArrayVar(&InitParameters, flagInit, []string{}, "initialization parameters for the run, available in the `init` context. Can be specified multiple times")
 	runCmd.Flags().StringVarP(&MintFilePath, "file", "f", "", "a Mint config file to use for sourcing task definitions (required)")
-	runCmd.Flags().StringVarP(&MintDirectory, "dir", "d", "", "the directory your Mint files are located in, typically `.mint`. By default, the CLI traverses up until it finds a `.mint` directory.")
+	addMintDirFlag(runCmd)
 	runCmd.Flags().BoolVar(&Open, "open", false, "open the run in a browser")
 	runCmd.Flags().BoolVar(&Debug, "debug", false, "start a remote debugging session once a breakpoint is hit")
 	runCmd.Flags().StringVar(&Title, "title", "", "the title the UI will display for the Mint run")

--- a/cmd/mint/update.go
+++ b/cmd/mint/update.go
@@ -51,15 +51,9 @@ var (
 )
 
 func updateBase(files []string) error {
-	replacementVersionPicker := cli.PickLatestMinorVersion
-	if AllowMajorVersionChange {
-		replacementVersionPicker = cli.PickLatestMajorVersion
-	}
-
 	_, err := service.UpdateBase(cli.UpdateBaseConfig{
-		Files:                    files,
-		MintDirectory:            MintDirectory,
-		ReplacementVersionPicker: replacementVersionPicker,
+		Files:         files,
+		MintDirectory: MintDirectory,
 	})
 	return err
 }
@@ -78,7 +72,6 @@ func updateLeaves(files []string) error {
 }
 
 func init() {
-	updateBaseCmd.Flags().BoolVar(&AllowMajorVersionChange, "allow-major-version-change", false, "update base layers to the latest major version")
 	addMintDirFlag(updateBaseCmd)
 
 	updateLeavesCmd.Flags().BoolVar(&AllowMajorVersionChange, "allow-major-version-change", false, "update leaves to the latest major version")

--- a/cmd/mint/update.go
+++ b/cmd/mint/update.go
@@ -58,7 +58,7 @@ func updateBase(files []string) error {
 
 	_, err := service.UpdateBase(cli.UpdateBaseConfig{
 		Files:                    files,
-		DefaultDir:               ".mint",
+		MintDirectory:            MintDirectory,
 		ReplacementVersionPicker: replacementVersionPicker,
 	})
 	return err
@@ -72,15 +72,20 @@ func updateLeaves(files []string) error {
 
 	return service.UpdateLeaves(cli.UpdateLeavesConfig{
 		Files:                    files,
-		DefaultDir:               ".mint",
+		MintDirectory:            MintDirectory,
 		ReplacementVersionPicker: replacementVersionPicker,
 	})
 }
 
 func init() {
 	updateBaseCmd.Flags().BoolVar(&AllowMajorVersionChange, "allow-major-version-change", false, "update base layers to the latest major version")
+	addMintDirFlag(updateBaseCmd)
+
 	updateLeavesCmd.Flags().BoolVar(&AllowMajorVersionChange, "allow-major-version-change", false, "update leaves to the latest major version")
+	addMintDirFlag(updateLeavesCmd)
+
 	updateCmd.Flags().BoolVar(&AllowMajorVersionChange, "allow-major-version-change", false, "update to the latest major version")
 	updateCmd.AddCommand(updateBaseCmd)
 	updateCmd.AddCommand(updateLeavesCmd)
+	addMintDirFlag(updateCmd)
 }

--- a/cmd/mint/update.go
+++ b/cmd/mint/update.go
@@ -9,16 +9,35 @@ var updateCmd = &cobra.Command{
 	Short: "Update versions for base layers and Mint leaves",
 	Use:   "update [flags] [files...]",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		if len(args) > 0 && args[0] == "leaves" {
-			return updateLeaves(args[1:])
+		if len(args) > 0 {
+			switch args[0] {
+			case "base":
+				return updateBase(args[1:])
+			case "leaves":
+				return updateLeaves(args[1:])
+			}
 		}
 
+		err := updateBase(args)
+		if err != nil {
+			return err
+		}
 		return updateLeaves(args)
 	},
 }
 
 var (
 	AllowMajorVersionChange bool
+
+	updateBaseCmd = &cobra.Command{
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return updateBase(args)
+		},
+		Short: "Update all base layers to their latest (minor) version",
+		Long: "Update all base layers to their latest (minor) version.\n" +
+			"Takes a list of files as arguments, or updates all toplevel YAML files in .mint if no files are given.",
+		Use: "base [flags] [files...]",
+	}
 
 	updateLeavesCmd = &cobra.Command{
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -30,6 +49,20 @@ var (
 		Use: "leaves [flags] [files...]",
 	}
 )
+
+func updateBase(files []string) error {
+	replacementVersionPicker := cli.PickLatestMinorVersion
+	if AllowMajorVersionChange {
+		replacementVersionPicker = cli.PickLatestMajorVersion
+	}
+
+	_, err := service.UpdateBase(cli.UpdateBaseConfig{
+		Files:                    files,
+		DefaultDir:               ".mint",
+		ReplacementVersionPicker: replacementVersionPicker,
+	})
+	return err
+}
 
 func updateLeaves(files []string) error {
 	replacementVersionPicker := cli.PickLatestMinorVersion
@@ -45,7 +78,9 @@ func updateLeaves(files []string) error {
 }
 
 func init() {
+	updateBaseCmd.Flags().BoolVar(&AllowMajorVersionChange, "allow-major-version-change", false, "update base layers to the latest major version")
 	updateLeavesCmd.Flags().BoolVar(&AllowMajorVersionChange, "allow-major-version-change", false, "update leaves to the latest major version")
 	updateCmd.Flags().BoolVar(&AllowMajorVersionChange, "allow-major-version-change", false, "update to the latest major version")
+	updateCmd.AddCommand(updateBaseCmd)
 	updateCmd.AddCommand(updateLeavesCmd)
 }

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -203,7 +203,7 @@ func (c Client) InitiateDispatch(cfg InitiateDispatchConfig) (*InitiateDispatchR
 
 	if resp.StatusCode != 201 {
 		errorStruct := struct {
-			Error  string `json:"error,omitempty"`
+			Error string `json:"error,omitempty"`
 		}{}
 
 		if err := json.NewDecoder(resp.Body).Decode(&errorStruct); err != nil {

--- a/internal/api/mint_directory_entry.go
+++ b/internal/api/mint_directory_entry.go
@@ -7,3 +7,11 @@ type MintDirectoryEntry struct {
 	Permissions  uint32 `json:"permissions"`
 	FileContents string `json:"file_contents"`
 }
+
+func (e MintDirectoryEntry) IsDir() bool {
+	return e.Type == "dir"
+}
+
+func (e MintDirectoryEntry) IsFile() bool {
+	return e.Type == "file"
+}

--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -172,16 +172,11 @@ func (c SetSecretsInVaultConfig) Validate() error {
 }
 
 type UpdateBaseConfig struct {
-	MintDirectory            string
-	Files                    []string
-	ReplacementVersionPicker func(versions api.LeafVersionsResult, leaf string, major string) (string, error) // TODO: no
+	MintDirectory string
+	Files         []string
 }
 
 func (c UpdateBaseConfig) Validate() error {
-	if c.ReplacementVersionPicker == nil {
-		return errors.New("a replacement version picker must be provided")
-	}
-
 	return nil
 }
 
@@ -276,7 +271,7 @@ type BaseLayerRunFile struct {
 	Spec         BaseLayerSpec
 	OriginalBase BaseLayerSpec
 	ResolvedBase BaseLayerSpec
-	Path         string
+	OriginalPath string
 	Error        error
 }
 

--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -169,6 +169,24 @@ func (c SetSecretsInVaultConfig) Validate() error {
 	return nil
 }
 
+type UpdateBaseConfig struct {
+	DefaultDir               string
+	Files                    []string
+	ReplacementVersionPicker func(versions api.LeafVersionsResult, leaf string, major string) (string, error) // TODO: no
+}
+
+func (c UpdateBaseConfig) Validate() error {
+	if len(c.Files) == 0 && c.DefaultDir == "" {
+		return errors.New("a default directory must be provided if not specifying files explicitly")
+	}
+
+	if c.ReplacementVersionPicker == nil {
+		return errors.New("a replacement version picker must be provided")
+	}
+
+	return nil
+}
+
 type UpdateLeavesConfig struct {
 	DefaultDir               string
 	Files                    []string

--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -3,9 +3,11 @@ package cli
 import (
 	"io"
 
+	"github.com/Masterminds/semver/v3"
 	"github.com/rwx-research/mint-cli/internal/accesstoken"
 	"github.com/rwx-research/mint-cli/internal/api"
 	"github.com/rwx-research/mint-cli/internal/errors"
+	"github.com/rwx-research/mint-cli/internal/versions"
 )
 
 type Config struct {
@@ -215,6 +217,14 @@ type BaseLayerSpec struct {
 	Arch string `yaml:"arch"`
 }
 
+func (b BaseLayerSpec) TagVersion() *semver.Version {
+	if b.Tag == "" {
+		return versions.EmptyVersion
+	}
+
+	return semver.MustParse(b.Tag)
+}
+
 func (b BaseLayerSpec) Equal(other BaseLayerSpec) bool {
 	if b.Os != other.Os {
 		return false
@@ -264,13 +274,14 @@ func (b BaseLayerSpec) Merge(other BaseLayerSpec) BaseLayerSpec {
 
 type BaseLayerRunFile struct {
 	Spec         BaseLayerSpec
+	OriginalBase BaseLayerSpec
 	ResolvedBase BaseLayerSpec
 	Path         string
 	Error        error
 }
 
 func (rf BaseLayerRunFile) HasChanges() bool {
-	return !rf.Spec.Equal(rf.ResolvedBase)
+	return !rf.OriginalBase.Equal(rf.ResolvedBase)
 }
 
 type ResolveBaseResult struct {

--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -253,7 +253,7 @@ func (b BaseLayerSpec) Merge(other BaseLayerSpec) BaseLayerSpec {
 type BaseLayerRunFile struct {
 	Spec         BaseLayerSpec
 	ResolvedBase BaseLayerSpec
-	Filepath     string
+	Path         string
 	Error        error
 	Updated      bool
 }

--- a/internal/cli/files.go
+++ b/internal/cli/files.go
@@ -1,0 +1,289 @@
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/rwx-research/mint-cli/internal/api"
+	"github.com/rwx-research/mint-cli/internal/errors"
+	"github.com/rwx-research/mint-cli/internal/fs"
+)
+
+type MintDirectoryEntry = api.MintDirectoryEntry
+type TaskDefinition = api.TaskDefinition
+
+type MintYAMLFile struct {
+	Entry MintDirectoryEntry
+	Doc   *YAMLDoc
+}
+
+// findMintDirectoryPath returns a configured directory, if it exists, or walks up
+// from the working directory to find a .mint directory.
+func findMintDirectoryPath(configuredDirectory string) (string, error) {
+	if configuredDirectory != "" {
+		return configuredDirectory, nil
+	}
+
+	workingDirectory, err := os.Getwd()
+	if err != nil {
+		return "", errors.Wrap(err, "unable to determine the working directory")
+	}
+
+	// otherwise, walk up the working directory looking at each basename
+	for {
+		workingDirHasMintDir, err := fs.Exists(filepath.Join(workingDirectory, ".mint"))
+		if err != nil {
+			return "", errors.Wrapf(err, "unable to determine if .mint exists in %q", workingDirectory)
+		}
+
+		if workingDirHasMintDir {
+			return filepath.Join(workingDirectory, ".mint"), nil
+		}
+
+		if workingDirectory == string(os.PathSeparator) {
+			return "", nil
+		}
+
+		parentDir, _ := filepath.Split(workingDirectory)
+		workingDirectory = filepath.Clean(parentDir)
+	}
+}
+
+// getFileOrDirectoryYAMLEntries gets a MintDirectoryEntry for every given YAML file, or all YAML files in mintDir when no files are provided.
+func getFileOrDirectoryYAMLEntries(files []string, mintDir string) ([]MintDirectoryEntry, error) {
+	entries, err := getFileOrDirectoryEntries(files, mintDir)
+	if err != nil {
+		return nil, err
+	}
+	return filterYAMLFiles(entries), nil
+}
+
+// getFileOrDirectoryEntries gets a MintDirectoryEntry for every given file, or all files in mintDir when no files are provided.
+func getFileOrDirectoryEntries(files []string, mintDir string) ([]MintDirectoryEntry, error) {
+	if len(files) > 0 {
+		return mintDirectoryEntriesFromPaths(files)
+	} else if mintDir != "" {
+		return mintDirectoryEntries(mintDir)
+	}
+	return make([]MintDirectoryEntry, 0), nil
+}
+
+// mintDirectoryEntries reads all files in the given dir and ensures the total size in within limits.
+func mintDirectoryEntries(dir string) ([]MintDirectoryEntry, error) {
+	entries := make([]MintDirectoryEntry, 0)
+	var totalSize int
+
+	err := filepath.Walk(dir, func(pathInDir string, info os.FileInfo, err error) error {
+		if err != nil {
+			return fmt.Errorf("error reading %q: %w", pathInDir, err)
+		}
+
+		entry, entrySize, err := mintDirectoryEntry(pathInDir, info, dir)
+		if err != nil {
+			return err
+		}
+
+		totalSize += entrySize
+		entries = append(entries, entry)
+
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("unable to retrieve the entire contents of the .mint directory %q: %w", dir, err)
+	}
+	if totalSize > 5*1024*1024 {
+		return nil, fmt.Errorf("the size of the .mint directory at %q exceeds 5MiB", dir)
+	}
+
+	return entries, nil
+}
+
+// mintDirectoryEntriesFromPaths reads given file paths and ensures the total size in within limits.
+func mintDirectoryEntriesFromPaths(paths []string) ([]MintDirectoryEntry, error) {
+	entries := make([]MintDirectoryEntry, 0)
+	var totalSize int
+
+	for _, path := range paths {
+		info, err := os.Lstat(path)
+		if err != nil {
+			return nil, errors.Wrapf(err, "error while stating %q", path)
+		}
+
+		entry, entrySize, err := mintDirectoryEntry(path, info, "")
+		if err != nil {
+			return nil, err
+		}
+
+		totalSize += entrySize
+		entries = append(entries, entry)
+	}
+	if totalSize > 5*1024*1024 {
+		return nil, fmt.Errorf("the size of the these files exceed 5MiB: %s", strings.Join(paths, ", "))
+	}
+
+	return entries, nil
+}
+
+// mintDirectoryEntry finds the file at path and converts it to a MintDirectoryEntry.
+func mintDirectoryEntry(path string, info os.FileInfo, makePathRelativeTo string) (MintDirectoryEntry, int, error) {
+	mode := info.Mode()
+	permissions := mode.Perm()
+
+	var entryType string
+	switch mode.Type() {
+	case os.ModeDir:
+		entryType = "dir"
+	case os.ModeSymlink:
+		entryType = "symlink"
+	case os.ModeNamedPipe:
+		entryType = "named-pipe"
+	case os.ModeSocket:
+		entryType = "socket"
+	case os.ModeDevice:
+		entryType = "device"
+	case os.ModeCharDevice:
+		entryType = "char-device"
+	case os.ModeIrregular:
+		entryType = "irregular"
+	default:
+		if mode.IsRegular() {
+			entryType = "file"
+		} else {
+			entryType = "unknown"
+		}
+	}
+
+	var fileContents string
+	var contentLength int
+	if entryType == "file" {
+		contents, err := os.ReadFile(path)
+		if err != nil {
+			return MintDirectoryEntry{}, contentLength, fmt.Errorf("unable to read file %q: %w", path, err)
+		}
+
+		contentLength = len(contents)
+		fileContents = string(contents)
+	}
+
+	relPath := path
+	if makePathRelativeTo != "" {
+		rel, err := filepath.Rel(makePathRelativeTo, path)
+		if err != nil {
+			return MintDirectoryEntry{}, contentLength, fmt.Errorf("unable to determine relative path of %q: %w", path, err)
+		}
+		relPath = filepath.ToSlash(filepath.Join(".mint", rel)) // Mint only supports unix-style path separators
+	}
+
+	return MintDirectoryEntry{
+		Type:         entryType,
+		OriginalPath: path,
+		Path:         relPath,
+		Permissions:  uint32(permissions),
+		FileContents: fileContents,
+	}, contentLength, nil
+}
+
+// taskDefinitionsFromPaths opens each file specified in `paths` and reads their content as a string.
+// No validation takes place here.
+func taskDefinitionsFromPaths(paths []string) ([]TaskDefinition, error) {
+	taskDefinitions := make([]api.TaskDefinition, 0)
+
+	for _, path := range paths {
+		fd, err := os.Open(path)
+		if err != nil {
+			return nil, errors.Wrapf(err, "error while opening %q", path)
+		}
+		defer fd.Close()
+
+		fileContent, err := io.ReadAll(fd)
+		if err != nil {
+			return nil, errors.Wrapf(err, "error while reading %q", path)
+		}
+
+		taskDefinitions = append(taskDefinitions, TaskDefinition{
+			Path:         path,
+			FileContents: string(fileContent),
+		})
+	}
+
+	return taskDefinitions, nil
+}
+
+// filterYAMLFiles finds any *.yml and *.yaml files in the given entries.
+// No further validation is made.
+func filterYAMLFiles(entries []MintDirectoryEntry) []MintDirectoryEntry {
+	yamlFiles := make([]MintDirectoryEntry, 0)
+
+	for _, entry := range entries {
+		if !isYAMLFile(entry) {
+			continue
+		}
+
+		yamlFiles = append(yamlFiles, entry)
+	}
+
+	return yamlFiles
+}
+
+// filterYAMLFilesForModification finds any *.yml and *.yaml files in the given entries
+// and reads and parses them. Entries that cannot be modified, such as JSON files
+// masquerading as YAML, will not be included.
+func filterYAMLFilesForModification(entries []MintDirectoryEntry, filter func(doc *YAMLDoc) bool) []*MintYAMLFile {
+	yamlFiles := make([]*MintYAMLFile, 0)
+
+	for _, entry := range entries {
+		yamlFile := validateYAMLFileForModification(entry, filter)
+		if yamlFile == nil {
+			continue
+		}
+
+		yamlFiles = append(yamlFiles, yamlFile)
+	}
+
+	return yamlFiles
+}
+
+// validateYAMLFileForModification reads and parses the given file entry. If it cannot
+// be modified, this method will return nil.
+func validateYAMLFileForModification(entry MintDirectoryEntry, filter func(doc *YAMLDoc) bool) *MintYAMLFile {
+	if !isYAMLFile(entry) {
+		return nil
+	}
+
+	content, err := os.ReadFile(entry.OriginalPath)
+	if err != nil {
+		return nil
+	}
+
+	// JSON is valid YAML, but we don't support modifying it
+	if isJSON(content) {
+		return nil
+	}
+
+	doc, err := ParseYamlDoc(string(content))
+	if err != nil {
+		return nil
+	}
+
+	if !filter(doc) {
+		return nil
+	}
+
+	return &MintYAMLFile{
+		Entry: entry,
+		Doc:   doc,
+	}
+}
+
+func isJSON(content []byte) bool {
+	var jsonContent any
+	return len(content) > 0 && content[0] == '{' && json.Unmarshal(content, &jsonContent) == nil
+}
+
+func isYAMLFile(entry MintDirectoryEntry) bool {
+	return entry.Type == "file" && (strings.HasSuffix(entry.OriginalPath, ".yml") || strings.HasSuffix(entry.OriginalPath, ".yaml"))
+}

--- a/internal/cli/files.go
+++ b/internal/cli/files.go
@@ -109,16 +109,19 @@ func readMintDirectoryEntries(paths []string, relativeTo string) ([]MintDirector
 	var totalSize int
 
 	for _, path := range paths {
-		filepath.WalkDir(path, func(subpath string, de os.DirEntry, err error) error {
-			entry, entrySize, err := mintDirectoryEntry(subpath, de, relativeTo)
-			if err != nil {
-				return err
+		err := filepath.WalkDir(path, func(subpath string, de os.DirEntry, err error) error {
+			entry, entrySize, suberr := mintDirectoryEntry(subpath, de, relativeTo)
+			if suberr != nil {
+				return suberr
 			}
 
 			totalSize += entrySize
 			entries = append(entries, entry)
 			return nil
 		})
+		if err != nil {
+			return nil, errors.Wrapf(err, "reading mint directory entries at %s", path)
+		}
 	}
 
 	if totalSize > 5*1024*1024 {

--- a/internal/cli/service.go
+++ b/internal/cli/service.go
@@ -1013,7 +1013,7 @@ func (s Service) resolveBaseSpecs(runFiles []BaseLayerRunFile) (map[BaseLayerSpe
 
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
-	errs, ctx := errgroup.WithContext(ctx)
+	errs, _ := errgroup.WithContext(ctx)
 	errs.SetLimit(3)
 
 	// Process each unique spec

--- a/internal/cli/service.go
+++ b/internal/cli/service.go
@@ -984,6 +984,9 @@ func (s Service) resolveBaseSpecs(runFiles []BaseLayerRunFile) (map[BaseLayerSpe
 
 func (s Service) writeRunFileWithBase(runFile BaseLayerRunFile) error {
 	doc, err := ParseYAMLFile(runFile.Path)
+	if err != nil {
+		return err
+	}
 
 	resolvedBase := runFile.ResolvedBase
 	base := map[string]any{
@@ -1076,11 +1079,6 @@ func PickLatestMinorVersion(versions api.LeafVersionsResult, leaf string, major 
 	}
 
 	return latestVersion, nil
-}
-
-func removeDuplicateStrings(list []string) []string {
-	slices.Sort(list)
-	return slices.Compact(list)
 }
 
 func findSnippets(fileNames []string) (nonSnippetFileNames []string, snippetFileNames []string) {

--- a/internal/cli/service_test.go
+++ b/internal/cli/service_test.go
@@ -2172,9 +2172,7 @@ tasks:
 
 		Context("when yaml file is actually json", func() {
 			BeforeEach(func() {
-				var err error
-
-				err = os.WriteFile(filepath.Join(mintDir, "bar.yaml"), []byte(`{
+				err := os.WriteFile(filepath.Join(mintDir, "bar.yaml"), []byte(`{
 "tasks": [
   { "key": "a" },
   { "key": "b" }
@@ -2306,9 +2304,7 @@ tasks:
 
 		Context("when yaml file has a base with os but no tag or arch", func() {
 			BeforeEach(func() {
-				var err error
-
-				err = os.WriteFile(filepath.Join(mintDir, "ci.yaml"), []byte(`on:
+				err := os.WriteFile(filepath.Join(mintDir, "ci.yaml"), []byte(`on:
   github:
     push: {}
 
@@ -2354,9 +2350,7 @@ tasks:
 
 		Context("when yaml file has a base with os and arch but no tag", func() {
 			BeforeEach(func() {
-				var err error
-
-				err = os.WriteFile(filepath.Join(mintDir, "ci.yaml"), []byte(`on:
+				err := os.WriteFile(filepath.Join(mintDir, "ci.yaml"), []byte(`on:
   github:
     push: {}
 
@@ -2404,9 +2398,7 @@ tasks:
 
 		Context("when yaml file has base after tasks with os but no tag", func() {
 			BeforeEach(func() {
-				var err error
-
-				err = os.WriteFile(filepath.Join(mintDir, "ci.yaml"), []byte(`on:
+				err := os.WriteFile(filepath.Join(mintDir, "ci.yaml"), []byte(`on:
   github:
     push: {}
 
@@ -2902,9 +2894,7 @@ tasks:
 
 		Context("when yaml file has a base with os and arch but no tag", func() {
 			BeforeEach(func() {
-				var err error
-
-				err = os.WriteFile(filepath.Join(mintDir, "ci.yaml"), []byte(`on:
+				err := os.WriteFile(filepath.Join(mintDir, "ci.yaml"), []byte(`on:
   github:
     push: {}
 
@@ -2952,9 +2942,7 @@ tasks:
 
 		Context("when yaml file has base after tasks with os but no tag", func() {
 			BeforeEach(func() {
-				var err error
-
-				err = os.WriteFile(filepath.Join(mintDir, "ci.yaml"), []byte(`on:
+				err := os.WriteFile(filepath.Join(mintDir, "ci.yaml"), []byte(`on:
   github:
     push: {}
 

--- a/internal/cli/service_test.go
+++ b/internal/cli/service_test.go
@@ -618,7 +618,7 @@ var _ = Describe("CLI Service", func() {
 				It("returns an error", func() {
 					_, err := service.InitiateRun(runConfig)
 					Expect(err).To(HaveOccurred())
-					Expect(err.Error()).To(ContainSubstring("could not be found"))
+					Expect(err.Error()).To(ContainSubstring("unable to find .mint directory"))
 				})
 			})
 		})
@@ -2155,7 +2155,7 @@ tasks:
 				})
 
 				Expect(err).To(HaveOccurred())
-				Expect(err.Error()).To(ContainSubstring(fmt.Sprintf("no files found in mint directory %q", mintDir)))
+				Expect(err.Error()).To(ContainSubstring(fmt.Sprintf("no files provided, and no yaml files found in directory %s", mintDir)))
 			})
 		})
 

--- a/internal/cli/service_test.go
+++ b/internal/cli/service_test.go
@@ -2234,11 +2234,10 @@ not-my-key:
 
 				contents, err = os.ReadFile(filepath.Join(mintDir, "bar.yaml"))
 				Expect(err).NotTo(HaveOccurred())
-				Expect(string(contents)).To(Equal(`
-base:
+				Expect(string(contents)).To(Equal(`base:
+  arch: quantum
   os: gentoo 99
   tag: 1.2
-  arch: quantum
 
 tasks:
   - key: a
@@ -2282,11 +2281,10 @@ tasks:
 
 				contents, err = os.ReadFile(filepath.Join(mintDir, "bar.yaml"))
 				Expect(err).NotTo(HaveOccurred())
-				Expect(string(contents)).To(Equal(`
-base:
+				Expect(string(contents)).To(Equal(`base:
+  arch: quantum
   os: gentoo 99
   tag: 1.2
-  arch: quantum
 
 tasks:
   - key: a
@@ -2314,7 +2312,7 @@ tasks:
 
 				err = os.WriteFile(filepath.Join(mintDir, "ci.yaml"), []byte(`on:
   github:
-    push:
+    push: {}
 
 base:
   os: gentoo 99
@@ -2340,7 +2338,7 @@ tasks:
 				Expect(err).NotTo(HaveOccurred())
 				Expect(string(contents)).To(Equal(`on:
   github:
-    push:
+    push: {}
 
 base:
   os: gentoo 99
@@ -2368,11 +2366,11 @@ tasks:
 
 				err = os.WriteFile(filepath.Join(mintDir, "ci.yaml"), []byte(`on:
   github:
-    push:
+    push: {}
 
 base:
   os: gentoo 99
-  arch: quantum # comment persists
+  arch: quantum # comment removed
 
 tasks:
   - key: a
@@ -2395,12 +2393,12 @@ tasks:
 				Expect(err).NotTo(HaveOccurred())
 				Expect(string(contents)).To(Equal(`on:
   github:
-    push:
+    push: {}
 
 base:
   os: gentoo 99
+  arch: quantum
   tag: 1.2
-  arch: quantum # comment persists
 
 tasks:
   - key: a
@@ -2424,7 +2422,7 @@ tasks:
 
 				err = os.WriteFile(filepath.Join(mintDir, "ci.yaml"), []byte(`on:
   github:
-    push:
+    push: {}
 
 tasks:
   - key: a
@@ -2449,7 +2447,7 @@ base:
 				Expect(err).NotTo(HaveOccurred())
 				Expect(string(contents)).To(Equal(`on:
   github:
-    push:
+    push: {}
 
 tasks:
   - key: a
@@ -2483,6 +2481,7 @@ base:
 
 				err = os.WriteFile(filepath.Join(mintDir, "two.yaml"), []byte(`base:
   os: gentoo 88
+
 tasks:
   - key: c
   - key: d

--- a/internal/cli/service_test.go
+++ b/internal/cli/service_test.go
@@ -1439,15 +1439,15 @@ AAAEC6442PQKevgYgeT0SIu9zwlnEMl6MF59ZgM+i0ByMv4eLJPqG3xnZcEQmktHj/GY2i
 
 					err = os.WriteFile(filepath.Join(mintDir, "bar.yaml"), []byte(`
 tasks:
-	- key: foo
-		call: mint/setup-node 1.2.3
+  - key: foo
+    call: mint/setup-node 1.2.3
 `), 0o644)
 					Expect(err).NotTo(HaveOccurred())
 
 					err = os.WriteFile(filepath.Join(mintDir, "baz.yaml"), []byte(`
 tasks:
-	- key: foo
-		call: mint/setup-node 1.2.3
+  - key: foo
+    call: mint/setup-node 1.2.3
 `), 0o644)
 					Expect(err).NotTo(HaveOccurred())
 
@@ -1457,8 +1457,8 @@ tasks:
 
 					err = os.WriteFile(filepath.Join(nestedDir, "tasks.yaml"), []byte(`
 tasks:
-	- key: foo
-		call: mint/setup-node 1.2.3
+  - key: foo
+    call: mint/setup-node 1.2.3
 `), 0o644)
 					Expect(err).NotTo(HaveOccurred())
 				})
@@ -1541,8 +1541,8 @@ tasks:
 
 					err := os.WriteFile(filepath.Join(tmp, "foo.yaml"), []byte(`
 tasks:
-	- key: foo
-		call: mint/setup-node 1.2.3
+  - key: foo
+    call: mint/setup-node 1.2.3
 `), 0o644)
 					Expect(err).NotTo(HaveOccurred())
 				})
@@ -1560,8 +1560,8 @@ tasks:
 					Expect(err).NotTo(HaveOccurred())
 					Expect(string(contents)).To(Equal(`
 tasks:
-	- key: foo
-		call: mint/setup-node 1.2.3
+  - key: foo
+    call: mint/setup-node 1.2.3
 `))
 				})
 
@@ -1589,20 +1589,20 @@ tasks:
 
 					originalFooContents = `
 tasks:
-	- key: foo
-		call: mint/setup-node 1.0.1
-	- key: bar
-		call: mint/setup-ruby 0.0.1
-	- key: baz
-		call: mint/setup-go
+  - key: foo
+    call: mint/setup-node 1.0.1
+  - key: bar
+    call: mint/setup-ruby 0.0.1
+  - key: baz
+    call: mint/setup-go
 `
 					err = os.WriteFile(filepath.Join(tmp, "foo.yaml"), []byte(originalFooContents), 0o644)
 					Expect(err).NotTo(HaveOccurred())
 
 					originalBarContents = `
 tasks:
-	- key: foo
-		call: mint/setup-ruby 1.0.0
+  - key: foo
+    call: mint/setup-ruby 1.0.0
 `
 					err = os.WriteFile(filepath.Join(tmp, "bar.yaml"), []byte(originalBarContents), 0o644)
 					Expect(err).NotTo(HaveOccurred())
@@ -1621,22 +1621,20 @@ tasks:
 
 					contents, err = os.ReadFile(filepath.Join(tmp, "foo.yaml"))
 					Expect(err).NotTo(HaveOccurred())
-					Expect(string(contents)).To(Equal(`
-tasks:
-	- key: foo
-		call: mint/setup-node 1.2.3
-	- key: bar
-		call: mint/setup-ruby 1.0.1
-	- key: baz
-		call: mint/setup-go 1.3.5
+					Expect(string(contents)).To(Equal(`tasks:
+  - key: foo
+    call: mint/setup-node 1.2.3
+  - key: bar
+    call: mint/setup-ruby 1.0.1
+  - key: baz
+    call: mint/setup-go 1.3.5
 `))
 
 					contents, err = os.ReadFile(filepath.Join(tmp, "bar.yaml"))
 					Expect(err).NotTo(HaveOccurred())
-					Expect(string(contents)).To(Equal(`
-tasks:
-	- key: foo
-		call: mint/setup-ruby 1.0.1
+					Expect(string(contents)).To(Equal(`tasks:
+  - key: foo
+    call: mint/setup-ruby 1.0.1
 `))
 				})
 
@@ -1672,10 +1670,9 @@ tasks:
 
 						contents, err = os.ReadFile(filepath.Join(tmp, "bar.yaml"))
 						Expect(err).NotTo(HaveOccurred())
-						Expect(string(contents)).To(Equal(`
-tasks:
-	- key: foo
-		call: mint/setup-ruby 1.0.1
+						Expect(string(contents)).To(Equal(`tasks:
+  - key: foo
+    call: mint/setup-ruby 1.0.1
 `))
 					})
 				})
@@ -1685,8 +1682,8 @@ tasks:
 				BeforeEach(func() {
 					err := os.WriteFile(filepath.Join(tmp, "foo.yaml"), []byte(`
 tasks:
-	- key: foo
-		call: mint/setup-node 1.0.1
+  - key: foo
+    call: mint/setup-node 1.0.1
 `), 0o644)
 					Expect(err).NotTo(HaveOccurred())
 				})
@@ -1704,8 +1701,8 @@ tasks:
 					Expect(err).NotTo(HaveOccurred())
 					Expect(string(contents)).To(Equal(`
 tasks:
-	- key: foo
-		call: mint/setup-node 1.0.1
+  - key: foo
+    call: mint/setup-node 1.0.1
 `))
 				})
 
@@ -1726,8 +1723,8 @@ tasks:
 
 					err := os.WriteFile(filepath.Join(tmp, "foo.yaml"), []byte(`
 tasks:
-	- key: foo
-		call: mint/setup-node 1.1.1
+  - key: foo
+    call: mint/setup-node 1.1.1
 `), 0o644)
 					Expect(err).NotTo(HaveOccurred())
 				})
@@ -1743,10 +1740,9 @@ tasks:
 
 					contents, err := os.ReadFile(filepath.Join(tmp, "foo.yaml"))
 					Expect(err).NotTo(HaveOccurred())
-					Expect(string(contents)).To(Equal(`
-tasks:
-	- key: foo
-		call: mint/setup-node 1.0.3
+					Expect(string(contents)).To(Equal(`tasks:
+  - key: foo
+    call: mint/setup-node 1.0.3
 `))
 				})
 			})
@@ -1770,8 +1766,8 @@ tasks:
 					BeforeEach(func() {
 						err := os.WriteFile(filepath.Join(tmp, "foo.yaml"), []byte(`
 tasks:
-	- key: foo
-		call: mint/setup-node 1.1.1
+  - key: foo
+    call: mint/setup-node 1.1.1
 `), 0o644)
 						Expect(err).NotTo(HaveOccurred())
 					})
@@ -1781,8 +1777,8 @@ tasks:
 						Expect(err).NotTo(HaveOccurred())
 						Expect(string(contents)).To(Equal(`
 tasks:
-	- key: foo
-		call: mint/setup-node 1.1.1
+  - key: foo
+    call: mint/setup-node 1.1.1
 `))
 					})
 
@@ -1795,8 +1791,8 @@ tasks:
 					BeforeEach(func() {
 						err := os.WriteFile(filepath.Join(tmp, "foo.yaml"), []byte(`
 tasks:
-	- key: foo
-		call: mint/setup-node 1.0.9
+  - key: foo
+    call: mint/setup-node 1.0.9
 `), 0o644)
 						Expect(err).NotTo(HaveOccurred())
 					})
@@ -1804,10 +1800,9 @@ tasks:
 					It("updates the file", func() {
 						contents, err := os.ReadFile(filepath.Join(tmp, "foo.yaml"))
 						Expect(err).NotTo(HaveOccurred())
-						Expect(string(contents)).To(Equal(`
-tasks:
-	- key: foo
-		call: mint/setup-node 1.1.1
+						Expect(string(contents)).To(Equal(`tasks:
+  - key: foo
+    call: mint/setup-node 1.1.1
 `))
 					})
 
@@ -1861,15 +1856,15 @@ tasks:
 
 					err = os.WriteFile(filepath.Join(mintDir, "bar.yaml"), []byte(`
 tasks:
-	- key: foo
-		call: mint/setup-node 1.2.3
+  - key: foo
+    call: mint/setup-node 1.2.3
 `), 0o644)
 					Expect(err).NotTo(HaveOccurred())
 
 					err = os.WriteFile(filepath.Join(mintDir, "baz.yaml"), []byte(`
 tasks:
-	- key: foo
-		call: mint/setup-node
+  - key: foo
+    call: mint/setup-node
 `), 0o644)
 					Expect(err).NotTo(HaveOccurred())
 
@@ -1879,8 +1874,8 @@ tasks:
 
 					err = os.WriteFile(filepath.Join(nestedDir, "tasks.yaml"), []byte(`
 tasks:
-	- key: foo
-		call: mint/setup-node # comment here
+  - key: foo
+    call: mint/setup-node
 `), 0o644)
 					Expect(err).NotTo(HaveOccurred())
 				})
@@ -1914,7 +1909,7 @@ tasks:
 
 					contents, err = os.ReadFile(filepath.Join(mintDir, "some", "nested", "dir", "tasks.yaml"))
 					Expect(err).NotTo(HaveOccurred())
-					Expect(string(contents)).To(ContainSubstring("mint/setup-node 1.3.0 # comment here"))
+					Expect(string(contents)).To(ContainSubstring("mint/setup-node 1.3.0"))
 				})
 			})
 		})
@@ -1962,8 +1957,8 @@ tasks:
 
 					err := os.WriteFile(filepath.Join(tmp, "foo.yaml"), []byte(`
 tasks:
-	- key: foo
-		call: mint/setup-node 1.2.3
+  - key: foo
+    call: mint/setup-node 1.2.3
 `), 0o644)
 					Expect(err).NotTo(HaveOccurred())
 				})
@@ -1981,8 +1976,8 @@ tasks:
 					Expect(err).NotTo(HaveOccurred())
 					Expect(string(contents)).To(Equal(`
 tasks:
-	- key: foo
-		call: mint/setup-node 1.2.3
+  - key: foo
+    call: mint/setup-node 1.2.3
 `))
 				})
 
@@ -2010,20 +2005,20 @@ tasks:
 
 					originalFooContents = `
 tasks:
-	- key: foo
-		call: mint/setup-node # comment
-	- key: bar
-		call: mint/setup-ruby 0.0.1
-	- key: baz
-		call: mint/setup-go
+  - key: foo
+    call: mint/setup-node
+  - key: bar
+    call: mint/setup-ruby 0.0.1
+  - key: baz
+    call: mint/setup-go
 `
 					err = os.WriteFile(filepath.Join(tmp, "foo.yaml"), []byte(originalFooContents), 0o644)
 					Expect(err).NotTo(HaveOccurred())
 
 					originalBarContents = `
 tasks:
-	- key: foo
-		call: mint/setup-ruby
+  - key: foo
+    call: mint/setup-ruby
 `
 					err = os.WriteFile(filepath.Join(tmp, "bar.yaml"), []byte(originalBarContents), 0o644)
 					Expect(err).NotTo(HaveOccurred())
@@ -2042,22 +2037,20 @@ tasks:
 
 					contents, err = os.ReadFile(filepath.Join(tmp, "foo.yaml"))
 					Expect(err).NotTo(HaveOccurred())
-					Expect(string(contents)).To(Equal(`
-tasks:
-	- key: foo
-		call: mint/setup-node 1.2.3 # comment
-	- key: bar
-		call: mint/setup-ruby 0.0.1
-	- key: baz
-		call: mint/setup-go 1.3.5
+					Expect(string(contents)).To(Equal(`tasks:
+  - key: foo
+    call: mint/setup-node 1.2.3
+  - key: bar
+    call: mint/setup-ruby 0.0.1
+  - key: baz
+    call: mint/setup-go 1.3.5
 `))
 
 					contents, err = os.ReadFile(filepath.Join(tmp, "bar.yaml"))
 					Expect(err).NotTo(HaveOccurred())
-					Expect(string(contents)).To(Equal(`
-tasks:
-	- key: foo
-		call: mint/setup-ruby 1.0.1
+					Expect(string(contents)).To(Equal(`tasks:
+  - key: foo
+    call: mint/setup-ruby 1.0.1
 `))
 				})
 
@@ -2091,10 +2084,9 @@ tasks:
 
 						contents, err = os.ReadFile(filepath.Join(tmp, "bar.yaml"))
 						Expect(err).NotTo(HaveOccurred())
-						Expect(string(contents)).To(Equal(`
-tasks:
-	- key: foo
-		call: mint/setup-ruby 1.0.1
+						Expect(string(contents)).To(Equal(`tasks:
+  - key: foo
+    call: mint/setup-ruby 1.0.1
 `))
 					})
 				})
@@ -2216,7 +2208,7 @@ tasks:
 				err = os.WriteFile(filepath.Join(mintDir, "baz.yaml"), []byte(`
 not-my-key:
   - key: qux
-   	call: mint/setup-node 1.2.3
+    call: mint/setup-node 1.2.3
 `), 0o644)
 				Expect(err).NotTo(HaveOccurred())
 			})
@@ -2255,7 +2247,7 @@ tasks:
 				Expect(string(contents)).To(Equal(`
 not-my-key:
   - key: qux
-   	call: mint/setup-node 1.2.3
+    call: mint/setup-node 1.2.3
 `))
 			})
 

--- a/internal/cli/service_test.go
+++ b/internal/cli/service_test.go
@@ -1417,7 +1417,7 @@ AAAEC6442PQKevgYgeT0SIu9zwlnEMl6MF59ZgM+i0ByMv4eLJPqG3xnZcEQmktHj/GY2i
 				It("returns an error", func() {
 					err := service.UpdateLeaves(cli.UpdateLeavesConfig{
 						Files:                    []string{},
-						DefaultDir:               mintDir,
+						MintDirectory:            mintDir,
 						ReplacementVersionPicker: cli.PickLatestMajorVersion,
 					})
 
@@ -1476,7 +1476,7 @@ tasks:
 
 					err = service.UpdateLeaves(cli.UpdateLeavesConfig{
 						Files:                    []string{},
-						DefaultDir:               mintDir,
+						MintDirectory:            mintDir,
 						ReplacementVersionPicker: cli.PickLatestMajorVersion,
 					})
 					Expect(err).NotTo(HaveOccurred())
@@ -1834,7 +1834,7 @@ tasks:
 
 				It("returns an error", func() {
 					_, err := service.ResolveLeaves(cli.ResolveLeavesConfig{
-						DefaultDir:          mintDir,
+						MintDirectory:       mintDir,
 						LatestVersionPicker: cli.PickLatestMajorVersion,
 					})
 
@@ -1892,7 +1892,7 @@ tasks:
 					var err error
 
 					_, err = service.ResolveLeaves(cli.ResolveLeavesConfig{
-						DefaultDir:          mintDir,
+						MintDirectory:       mintDir,
 						LatestVersionPicker: cli.PickLatestMajorVersion,
 					})
 					Expect(err).NotTo(HaveOccurred())
@@ -1942,7 +1942,7 @@ tasks:
 
 				It("returns an error", func() {
 					_, err := service.ResolveLeaves(cli.ResolveLeavesConfig{
-						DefaultDir:          tmp,
+						MintDirectory:       tmp,
 						LatestVersionPicker: cli.PickLatestMajorVersion,
 					})
 
@@ -1967,7 +1967,7 @@ tasks:
 					var err error
 
 					_, err = service.ResolveLeaves(cli.ResolveLeavesConfig{
-						DefaultDir:          tmp,
+						MintDirectory:       tmp,
 						LatestVersionPicker: cli.PickLatestMajorVersion,
 					})
 					Expect(err).NotTo(HaveOccurred())
@@ -1983,7 +1983,7 @@ tasks:
 
 				It("indicates no leaves were resolved", func() {
 					_, err := service.ResolveLeaves(cli.ResolveLeavesConfig{
-						DefaultDir:          tmp,
+						MintDirectory:       tmp,
 						LatestVersionPicker: cli.PickLatestMajorVersion,
 					})
 
@@ -2028,7 +2028,7 @@ tasks:
 					var err error
 
 					_, err = service.ResolveLeaves(cli.ResolveLeavesConfig{
-						DefaultDir:          tmp,
+						MintDirectory:       tmp,
 						LatestVersionPicker: cli.PickLatestMajorVersion,
 					})
 					Expect(err).NotTo(HaveOccurred())
@@ -2056,7 +2056,7 @@ tasks:
 
 				It("indicates leaves were resolved", func() {
 					_, err := service.ResolveLeaves(cli.ResolveLeavesConfig{
-						DefaultDir:          tmp,
+						MintDirectory:       tmp,
 						LatestVersionPicker: cli.PickLatestMajorVersion,
 					})
 
@@ -2072,7 +2072,7 @@ tasks:
 						var err error
 
 						_, err = service.ResolveLeaves(cli.ResolveLeavesConfig{
-							DefaultDir:          tmp,
+							MintDirectory:       tmp,
 							Files:               []string{filepath.Join(tmp, "bar.yaml")},
 							LatestVersionPicker: cli.PickLatestMajorVersion,
 						})
@@ -2151,7 +2151,7 @@ tasks:
 
 			It("returns an error", func() {
 				_, err := service.ResolveBase(cli.ResolveBaseConfig{
-					DefaultDir: mintDir,
+					MintDirectory: mintDir,
 				})
 
 				Expect(err).To(HaveOccurred())
@@ -2178,7 +2178,7 @@ tasks:
 
 			It("ignores the file", func() {
 				_, err := service.ResolveBase(cli.ResolveBaseConfig{
-					DefaultDir: mintDir,
+					MintDirectory: mintDir,
 				})
 
 				Expect(err).NotTo(HaveOccurred())
@@ -2217,8 +2217,8 @@ not-my-key:
 				var err error
 
 				_, err = service.ResolveBase(cli.ResolveBaseConfig{
-					DefaultDir: mintDir,
-					Arch:       "quantum",
+					MintDirectory: mintDir,
+					Arch:          "quantum",
 				})
 				Expect(err).NotTo(HaveOccurred())
 
@@ -2263,9 +2263,9 @@ tasks:
 				Expect(err).NotTo(HaveOccurred())
 
 				_, err = service.ResolveBase(cli.ResolveBaseConfig{
-					DefaultDir: mintDir,
-					Files:      []string{"bar.yaml"},
-					Arch:       "quantum",
+					MintDirectory: mintDir,
+					Files:         []string{"bar.yaml"},
+					Arch:          "quantum",
 				})
 				Expect(err).NotTo(HaveOccurred())
 
@@ -2320,7 +2320,7 @@ tasks:
 				var err error
 
 				_, err = service.ResolveBase(cli.ResolveBaseConfig{
-					DefaultDir: mintDir,
+					MintDirectory: mintDir,
 				})
 				Expect(err).NotTo(HaveOccurred())
 
@@ -2375,7 +2375,7 @@ tasks:
 				var err error
 
 				_, err = service.ResolveBase(cli.ResolveBaseConfig{
-					DefaultDir: mintDir,
+					MintDirectory: mintDir,
 				})
 				Expect(err).NotTo(HaveOccurred())
 
@@ -2429,7 +2429,7 @@ base:
 				var err error
 
 				_, err = service.ResolveBase(cli.ResolveBaseConfig{
-					DefaultDir: mintDir,
+					MintDirectory: mintDir,
 				})
 				Expect(err).NotTo(HaveOccurred())
 
@@ -2491,8 +2491,8 @@ tasks:
 				var err error
 
 				_, err = service.ResolveBase(cli.ResolveBaseConfig{
-					DefaultDir: mintDir,
-					Os:         "gentoo 99",
+					MintDirectory: mintDir,
+					Os:            "gentoo 99",
 				})
 				Expect(err).NotTo(HaveOccurred())
 
@@ -2554,7 +2554,7 @@ tasks:
 					}
 
 					_, err = service.ResolveBase(cli.ResolveBaseConfig{
-						DefaultDir: mintDir,
+						MintDirectory: mintDir,
 					})
 					Expect(err).To(HaveOccurred())
 					Expect(err.Error()).To(ContainSubstring("API request failed"))

--- a/internal/cli/yaml.go
+++ b/internal/cli/yaml.go
@@ -1,0 +1,205 @@
+package cli
+
+import (
+	"fmt"
+	"slices"
+	"strconv"
+	"strings"
+
+	"github.com/goccy/go-yaml"
+	"github.com/goccy/go-yaml/ast"
+	"github.com/goccy/go-yaml/parser"
+	"github.com/rwx-research/mint-cli/internal/errors"
+)
+
+type YamlDoc struct {
+	astFile *ast.File
+}
+
+func ParseYamlDoc(contents string) (*YamlDoc, error) {
+	astFile, err := parser.ParseBytes([]byte(contents), parser.ParseComments)
+	if err != nil {
+		return nil, err
+	}
+
+	return &YamlDoc{astFile: astFile}, nil
+}
+
+func (doc *YamlDoc) Bytes() []byte {
+	return []byte(doc.String())
+}
+
+func (doc *YamlDoc) String() string {
+	return doc.astFile.String()
+}
+
+func (doc *YamlDoc) HasBase() bool {
+	return doc.hasPath("$.base")
+}
+
+func (doc *YamlDoc) HasTasks() bool {
+	return doc.hasPath("$.tasks")
+}
+
+func (doc *YamlDoc) ReadStringAtPath(yamlPath string) (string, error) {
+	node, err := doc.getNodeAtPath(yamlPath)
+	if err != nil {
+		return "", err
+	}
+
+	return node.String(), nil
+}
+
+func (doc *YamlDoc) TryReadStringAtPath(yamlPath string) string {
+	str, err := doc.ReadStringAtPath(yamlPath)
+	if err != nil {
+		return ""
+	}
+	return str
+}
+
+func (doc *YamlDoc) InsertOrUpdateBase(spec BaseLayerSpec) error {
+	base := map[string]any{
+		"os": spec.Os,
+	}
+
+	// Prevent unnecessary quoting of float-like tags, eg. 1.2
+	if strings.Count(spec.Tag, ".") == 1 {
+		parsedTag, err := strconv.ParseFloat(spec.Tag, 64)
+		if err != nil {
+			return err
+		}
+		base["tag"] = parsedTag
+	} else {
+		base["tag"] = spec.Tag
+	}
+
+	if spec.Arch != "" && spec.Arch != "x86_64" {
+		base["arch"] = spec.Arch
+	}
+
+	if !doc.HasBase() {
+		return doc.InsertBefore("$.tasks", map[string]any{
+			"base": base,
+		})
+	} else {
+		return doc.MergeAtPath("$.base", base)
+	}
+}
+
+func (doc *YamlDoc) InsertBefore(beforeYamlPath string, value any) error {
+	if strings.Count(beforeYamlPath, ".") != 1 {
+		return errors.New("must provide a root yaml field in the form of \"$.fieldname\"")
+	}
+
+	p, err := yaml.PathString(beforeYamlPath)
+	if err != nil {
+		panic(err)
+	}
+
+	// We can't use doc.astFile because it may have already been modified and
+	// we need the original index for the relative yaml node.
+	reparsedFile, err := parser.ParseBytes([]byte(doc.astFile.String()), parser.ParseComments)
+	if err != nil {
+		return err
+	}
+
+	relativeNode, err := p.FilterFile(reparsedFile)
+	if err != nil {
+		return err
+	}
+
+	// token: value for the given beforeYamlPath
+	// token.Prev: the separator token, eg. ":"
+	// token.Prev.Prev: key for the given beforeYamlPath
+	token := relativeNode.GetToken()
+	idx := token.Prev.Prev.Position.Offset - 1
+
+	node, err := yaml.NewEncoder(nil).EncodeToNode(value)
+	if err != nil {
+		return err
+	}
+
+	toInsert := fmt.Appendf([]byte(node.String()), "\n\n")
+	result := slices.Insert([]byte(doc.astFile.String()), idx, toInsert...)
+
+	updatedDoc, err := ParseYamlDoc(string(result))
+	if err != nil {
+		return err
+	}
+
+	*doc = *updatedDoc
+
+	return nil
+}
+
+func (doc *YamlDoc) MergeAtPath(yamlPath string, value any) error {
+	p, err := yaml.PathString(yamlPath)
+	if err != nil {
+		panic(err)
+	}
+
+	node, err := yaml.NewEncoder(nil).EncodeToNode(value)
+	if err != nil {
+		return err
+	}
+
+	return p.MergeFromNode(doc.astFile, node)
+}
+
+func (doc *YamlDoc) ReplaceAtPath(yamlPath string, replacement any) error {
+	p, err := yaml.PathString(yamlPath)
+	if err != nil {
+		panic(err)
+	}
+
+	// Ensure the path exists
+	if _, err := p.FilterFile(doc.astFile); err != nil {
+		return err
+	}
+
+	node, err := yaml.NewEncoder(nil).EncodeToNode(replacement)
+	if err != nil {
+		return err
+	}
+
+	return p.ReplaceWithNode(doc.astFile, node)
+}
+
+func (doc *YamlDoc) SetAtPath(yamlPath string, value any) error {
+	pathParts := strings.Split(yamlPath, ".")
+	field := pathParts[len(pathParts)-1]
+
+	parent := strings.Join(pathParts[0:len(pathParts)-1], ".")
+	path, err := yaml.PathString(parent)
+	if err != nil {
+		panic(err)
+	}
+
+	node, err := yaml.NewEncoder(nil).EncodeToNode(map[string]any{
+		field: value,
+	})
+	if err != nil {
+		return err
+	}
+
+	return path.MergeFromNode(doc.astFile, node)
+}
+
+func (doc *YamlDoc) getNodeAtPath(yamlPath string) (ast.Node, error) {
+	p, err := yaml.PathString(yamlPath)
+	if err != nil {
+		panic(err)
+	}
+
+	return p.FilterFile(doc.astFile)
+}
+
+func (doc *YamlDoc) hasPath(yamlPath string) bool {
+	_, err := doc.getNodeAtPath(yamlPath)
+	if err != nil {
+		return false
+	}
+
+	return true
+}

--- a/internal/cli/yaml.go
+++ b/internal/cli/yaml.go
@@ -105,6 +105,12 @@ func (doc *YAMLDoc) InsertBefore(beforeYamlPath string, value any) error {
 	// token.Prev: the separator token, eg. ":"
 	// token.Prev.Prev: key for the given beforeYamlPath
 	token := relativeNode.GetToken()
+	if token.Prev == nil {
+		return errors.New("unexpected token structure: token.Prev is nil")
+	}
+	if token.Prev.Prev == nil {
+		return errors.New("unexpected token structure: token.Prev.Prev is nil")
+	}
 	idx := token.Prev.Prev.Position.Offset - 1
 
 	node, err := yaml.NewEncoder(nil).EncodeToNode(value)

--- a/internal/cli/yaml.go
+++ b/internal/cli/yaml.go
@@ -237,11 +237,7 @@ func (doc *YAMLDoc) getNodeAtPath(yamlPath string) (ast.Node, error) {
 
 func (doc *YAMLDoc) hasPath(yamlPath string) bool {
 	_, err := doc.getNodeAtPath(yamlPath)
-	if err != nil {
-		return false
-	}
-
-	return true
+	return err == nil
 }
 
 func (doc *YAMLDoc) modified() {

--- a/internal/cli/yaml_test.go
+++ b/internal/cli/yaml_test.go
@@ -17,7 +17,7 @@ a:
   b: hello
 `
 
-			doc, err := cli.ParseYamlDoc(contents)
+			doc, err := cli.ParseYAMLDoc(contents)
 			Expect(err).NotTo(HaveOccurred())
 
 			Expect(doc.TryReadStringAtPath("$.a.c")).To(Equal(""))
@@ -29,7 +29,7 @@ a:
   b: hello
 `
 
-			doc, err := cli.ParseYamlDoc(contents)
+			doc, err := cli.ParseYAMLDoc(contents)
 			Expect(err).NotTo(HaveOccurred())
 
 			Expect(doc.ReadStringAtPath("$.a.b")).To(Equal("hello"))
@@ -43,7 +43,7 @@ tasks-but-not-really:
   - key: task2
 `
 
-			doc, err := cli.ParseYamlDoc(contents)
+			doc, err := cli.ParseYAMLDoc(contents)
 			Expect(err).NotTo(HaveOccurred())
 
 			Expect(doc.HasTasks()).To(BeFalse())
@@ -60,7 +60,7 @@ tasks:
   - key: task2
 `
 
-			doc, err := cli.ParseYamlDoc(contents)
+			doc, err := cli.ParseYAMLDoc(contents)
 			Expect(err).NotTo(HaveOccurred())
 
 			Expect(doc.HasTasks()).To(BeTrue())
@@ -74,103 +74,10 @@ tasks-but-not-really:
   - key: task2
 `
 
-			doc, err := cli.ParseYamlDoc(contents)
+			doc, err := cli.ParseYAMLDoc(contents)
 			Expect(err).NotTo(HaveOccurred())
 
 			Expect(doc.HasTasks()).To(BeFalse())
-		})
-	})
-
-	Context("InsertOrUpdateBase", func() {
-		It("inserts missing base before tasks", func() {
-			contents := `
-on:
-  github:
-    push:
-      init:
-        commit-sha: ${{ event.git.sha }}
-
-tag: not it
-
-base:
-  # comment
-  os: linux
-  tag: 1.0
-
-tasks:
-  - key: task1 # another line comment
-  - key: task2
-`
-
-			doc, err := cli.ParseYamlDoc(contents)
-			Expect(err).NotTo(HaveOccurred())
-
-			err = doc.InsertOrUpdateBase(cli.BaseLayerSpec{
-				Os:   "linux",
-				Tag:  "1.2",
-				Arch: "x86_64",
-			})
-			Expect(err).NotTo(HaveOccurred())
-			Expect(doc.String()).To(Equal(`on:
-  github:
-    push:
-      init:
-        commit-sha: ${{ event.git.sha }}
-
-tag: not it
-
-base:
-  # comment
-  os: linux
-  tag: 1.2
-
-tasks:
-  - key: task1 # another line comment
-  - key: task2
-`))
-		})
-
-		It("updates existing base", func() {
-			contents := `
-on:
-  github:
-    push:
-      init:
-        commit-sha: ${{ event.git.sha }}
-
-tag: not it
-
-tasks:
-  - key: task1 # another line comment
-  - key: task2
-`
-
-			doc, err := cli.ParseYamlDoc(contents)
-			Expect(err).NotTo(HaveOccurred())
-
-			err = doc.InsertOrUpdateBase(cli.BaseLayerSpec{
-				Os:   "linux",
-				Tag:  "1.2",
-				Arch: "arm64",
-			})
-			Expect(err).NotTo(HaveOccurred())
-			Expect(doc.String()).To(Equal(`on:
-  github:
-    push:
-      init:
-        commit-sha: ${{ event.git.sha }}
-
-tag: not it
-
-base:
-  arch: arm64
-  os: linux
-  tag: 1.2
-
-tasks:
-  - key: task1 # another line comment
-  - key: task2
-`))
 		})
 	})
 
@@ -190,7 +97,7 @@ tasks:
   - key: task2
 `
 
-			doc, err := cli.ParseYamlDoc(contents)
+			doc, err := cli.ParseYAMLDoc(contents)
 			Expect(err).NotTo(HaveOccurred())
 
 			err = doc.InsertBefore("$.tasks", map[string]any{
@@ -227,7 +134,7 @@ tasks:
   - key: task2
 `
 
-			doc, err := cli.ParseYamlDoc(contents)
+			doc, err := cli.ParseYAMLDoc(contents)
 			Expect(err).NotTo(HaveOccurred())
 
 			err = doc.MergeAtPath("$.base", map[string]any{
@@ -260,7 +167,7 @@ tasks:
   - key: task2
 `
 
-			doc, err := cli.ParseYamlDoc(contents)
+			doc, err := cli.ParseYAMLDoc(contents)
 			Expect(err).NotTo(HaveOccurred())
 
 			err = doc.MergeAtPath("$.base", map[string]any{
@@ -295,7 +202,7 @@ tasks:
   - key: task2
 `
 
-			doc, err := cli.ParseYamlDoc(contents)
+			doc, err := cli.ParseYAMLDoc(contents)
 			Expect(err).NotTo(HaveOccurred())
 
 			err = doc.MergeAtPath("$.base", map[string]any{
@@ -330,7 +237,7 @@ tasks:
   - key: task2
 `
 
-			doc, err := cli.ParseYamlDoc(contents)
+			doc, err := cli.ParseYAMLDoc(contents)
 			Expect(err).NotTo(HaveOccurred())
 
 			err = doc.ReplaceAtPath("$.base.tag", 1.2)
@@ -362,7 +269,7 @@ tasks:
   - key: task2
 `
 
-			doc, err := cli.ParseYamlDoc(contents)
+			doc, err := cli.ParseYAMLDoc(contents)
 			Expect(err).NotTo(HaveOccurred())
 
 			err = doc.ReplaceAtPath("$.base.tag", 1.2)
@@ -392,7 +299,7 @@ tasks:
   - key: task2
 `
 
-			doc, err := cli.ParseYamlDoc(contents)
+			doc, err := cli.ParseYAMLDoc(contents)
 			Expect(err).NotTo(HaveOccurred())
 
 			err = doc.SetAtPath("$.base", map[string]any{

--- a/internal/cli/yaml_test.go
+++ b/internal/cli/yaml_test.go
@@ -1,0 +1,421 @@
+package cli_test
+
+import (
+	"github.com/goccy/go-yaml"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/rwx-research/mint-cli/internal/cli"
+	"github.com/rwx-research/mint-cli/internal/errors"
+)
+
+var _ = Describe("YamlDoc", func() {
+	Context("TryReadStringAtPath", func() {
+		It("returns an empty string when the path is not found", func() {
+			contents := `
+a:
+  b: hello
+`
+
+			doc, err := cli.ParseYamlDoc(contents)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(doc.TryReadStringAtPath("$.a.c")).To(Equal(""))
+		})
+
+		It("returns a string value at the given path", func() {
+			contents := `
+a:
+  b: hello
+`
+
+			doc, err := cli.ParseYamlDoc(contents)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(doc.ReadStringAtPath("$.a.b")).To(Equal("hello"))
+		})
+
+		It("returns false when tasks are not found", func() {
+			contents := `
+tasks-but-not-really:
+  - key: task1
+    tasks: [still, no]
+  - key: task2
+`
+
+			doc, err := cli.ParseYamlDoc(contents)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(doc.HasTasks()).To(BeFalse())
+		})
+	})
+	Context("HasTasks", func() {
+		It("returns true when tasks are not found", func() {
+			contents := `
+on:
+  github:
+
+tasks:
+  - key: task1
+  - key: task2
+`
+
+			doc, err := cli.ParseYamlDoc(contents)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(doc.HasTasks()).To(BeTrue())
+		})
+
+		It("returns false when tasks are not found", func() {
+			contents := `
+tasks-but-not-really:
+  - key: task1
+    tasks: [still, no]
+  - key: task2
+`
+
+			doc, err := cli.ParseYamlDoc(contents)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(doc.HasTasks()).To(BeFalse())
+		})
+	})
+
+	Context("InsertOrUpdateBase", func() {
+		It("inserts missing base before tasks", func() {
+			contents := `
+on:
+  github:
+    push:
+      init:
+        commit-sha: ${{ event.git.sha }}
+
+tag: not it
+
+base:
+  # comment
+  os: linux
+  tag: 1.0
+
+tasks:
+  - key: task1 # another line comment
+  - key: task2
+`
+
+			doc, err := cli.ParseYamlDoc(contents)
+			Expect(err).NotTo(HaveOccurred())
+
+			err = doc.InsertOrUpdateBase(cli.BaseLayerSpec{
+				Os:   "linux",
+				Tag:  "1.2",
+				Arch: "x86_64",
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(doc.String()).To(Equal(`on:
+  github:
+    push:
+      init:
+        commit-sha: ${{ event.git.sha }}
+
+tag: not it
+
+base:
+  # comment
+  os: linux
+  tag: 1.2
+
+tasks:
+  - key: task1 # another line comment
+  - key: task2
+`))
+		})
+
+		It("updates existing base", func() {
+			contents := `
+on:
+  github:
+    push:
+      init:
+        commit-sha: ${{ event.git.sha }}
+
+tag: not it
+
+tasks:
+  - key: task1 # another line comment
+  - key: task2
+`
+
+			doc, err := cli.ParseYamlDoc(contents)
+			Expect(err).NotTo(HaveOccurred())
+
+			err = doc.InsertOrUpdateBase(cli.BaseLayerSpec{
+				Os:   "linux",
+				Tag:  "1.2",
+				Arch: "arm64",
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(doc.String()).To(Equal(`on:
+  github:
+    push:
+      init:
+        commit-sha: ${{ event.git.sha }}
+
+tag: not it
+
+base:
+  arch: arm64
+  os: linux
+  tag: 1.2
+
+tasks:
+  - key: task1 # another line comment
+  - key: task2
+`))
+		})
+	})
+
+	Context("InsertBefore", func() {
+		It("inserts a yaml object before the given path", func() {
+			contents := `
+on:
+  github:
+    push:
+      init:
+        commit-sha: ${{ event.git.sha }}
+
+tag: not it
+
+tasks:
+  - key: task1 # another line comment
+  - key: task2
+`
+
+			doc, err := cli.ParseYamlDoc(contents)
+			Expect(err).NotTo(HaveOccurred())
+
+			err = doc.InsertBefore("$.tasks", map[string]any{
+				"base": map[string]any{
+					"os":   "linux",
+					"tag":  1.2,
+					"arch": "x86_64",
+				},
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(doc.String()).To(Equal(`on:
+  github:
+    push:
+      init:
+        commit-sha: ${{ event.git.sha }}
+
+tag: not it
+
+base:
+  arch: x86_64
+  os: linux
+  tag: 1.2
+
+tasks:
+  - key: task1 # another line comment
+  - key: task2
+`))
+		})
+
+		It("errors when the path is not found", func() {
+			contents := `
+tasks:
+  - key: task1
+  - key: task2
+`
+
+			doc, err := cli.ParseYamlDoc(contents)
+			Expect(err).NotTo(HaveOccurred())
+
+			err = doc.MergeAtPath("$.base", map[string]any{
+				"tag":  1.2,
+				"arch": "x86_64",
+			})
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("failed to find path ( $.base ): node not found"))
+			Expect(errors.Is(err, yaml.ErrNotFoundNode)).To(BeTrue())
+		})
+	})
+
+	Context("MergeAtPath", func() {
+		It("merges a yaml object at a specific path", func() {
+			contents := `
+on:
+  github:
+    push:
+      init:
+        commit-sha: ${{ event.git.sha }}
+
+tag: not it
+
+base:
+  # comment
+  os: linux
+
+tasks:
+  - key: task1 # another line comment
+  - key: task2
+`
+
+			doc, err := cli.ParseYamlDoc(contents)
+			Expect(err).NotTo(HaveOccurred())
+
+			err = doc.MergeAtPath("$.base", map[string]any{
+				"tag":  1.2,
+				"arch": "x86_64",
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(doc.String()).To(Equal(`on:
+  github:
+    push:
+      init:
+        commit-sha: ${{ event.git.sha }}
+
+tag: not it
+
+base:
+  # comment
+  os: linux
+  arch: x86_64
+  tag: 1.2
+
+tasks:
+  - key: task1 # another line comment
+  - key: task2
+`))
+		})
+
+		It("errors when the path is not found", func() {
+			contents := `
+tasks:
+  - key: task1
+  - key: task2
+`
+
+			doc, err := cli.ParseYamlDoc(contents)
+			Expect(err).NotTo(HaveOccurred())
+
+			err = doc.MergeAtPath("$.base", map[string]any{
+				"tag":  1.2,
+				"arch": "x86_64",
+			})
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("failed to find path ( $.base ): node not found"))
+			Expect(errors.Is(err, yaml.ErrNotFoundNode)).To(BeTrue())
+		})
+	})
+
+	Context("ReplaceAtPath", func() {
+		It("replaces a yaml file at a specific path", func() {
+			contents := `
+on:
+  github:
+    push:
+      init:
+        commit-sha: ${{ event.git.sha }}
+
+tag: not it
+
+base:
+  # comment
+  os: linux
+  tag: 1.0   # comment here
+  arch: x86_64
+
+tasks:
+  - key: task1 # another line comment
+  - key: task2
+`
+
+			doc, err := cli.ParseYamlDoc(contents)
+			Expect(err).NotTo(HaveOccurred())
+
+			err = doc.ReplaceAtPath("$.base.tag", 1.2)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(doc.String()).To(Equal(`on:
+  github:
+    push:
+      init:
+        commit-sha: ${{ event.git.sha }}
+
+tag: not it
+
+base:
+  # comment
+  os: linux
+  tag: 1.2
+  arch: x86_64
+
+tasks:
+  - key: task1 # another line comment
+  - key: task2
+`))
+		})
+
+		It("errors when the path is not found", func() {
+			contents := `
+tasks:
+  - key: task1
+  - key: task2
+`
+
+			doc, err := cli.ParseYamlDoc(contents)
+			Expect(err).NotTo(HaveOccurred())
+
+			err = doc.ReplaceAtPath("$.base.tag", 1.2)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("failed to find path ( $.base.tag ): node not found"))
+			Expect(errors.Is(err, yaml.ErrNotFoundNode)).To(BeTrue())
+		})
+	})
+
+	Context("SetAtPath", func() {
+		It("sets and overwrites a yaml object at a specific path", func() {
+			contents := `
+on:
+  github:
+    push:
+      init:
+        commit-sha: ${{ event.git.sha }}
+
+tag: not it
+
+base:
+  # comment
+  old: true
+
+tasks:
+  - key: task1 # another line comment
+  - key: task2
+`
+
+			doc, err := cli.ParseYamlDoc(contents)
+			Expect(err).NotTo(HaveOccurred())
+
+			err = doc.SetAtPath("$.base", map[string]any{
+				"os":  "linux",
+				"tag": 1.2,
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(doc.String()).To(Equal(`on:
+  github:
+    push:
+      init:
+        commit-sha: ${{ event.git.sha }}
+
+tag: not it
+
+base:
+  os: linux
+  tag: 1.2
+
+tasks:
+  - key: task1 # another line comment
+  - key: task2
+`))
+		})
+	})
+})

--- a/internal/versions/versions.go
+++ b/internal/versions/versions.go
@@ -10,7 +10,8 @@ import (
 )
 
 var versionHolder *lockedVersions
-var emptyVersion = semver.MustParse("0.0.0")
+
+var EmptyVersion = semver.MustParse("0.0.0")
 
 type lockedVersions struct {
 	currentVersion *semver.Version
@@ -27,7 +28,7 @@ func init() {
 
 	versionHolder = &lockedVersions{
 		currentVersion: currentVersion,
-		latestVersion:  emptyVersion,
+		latestVersion:  EmptyVersion,
 	}
 }
 
@@ -63,7 +64,7 @@ func NewVersionAvailable() bool {
 }
 
 func HasCliLatestVersion() bool {
-	return !GetCliLatestVersion().Equal(emptyVersion)
+	return !GetCliLatestVersion().Equal(EmptyVersion)
 }
 
 func InstalledWithHomebrew() bool {

--- a/internal/versions/versions.go
+++ b/internal/versions/versions.go
@@ -10,6 +10,7 @@ import (
 )
 
 var versionHolder *lockedVersions
+var emptyVersion = semver.MustParse("0.0.0")
 
 type lockedVersions struct {
 	currentVersion *semver.Version
@@ -26,7 +27,7 @@ func init() {
 
 	versionHolder = &lockedVersions{
 		currentVersion: currentVersion,
-		latestVersion:  semver.MustParse("0.0.0"),
+		latestVersion:  emptyVersion,
 	}
 }
 
@@ -59,6 +60,10 @@ func NewVersionAvailable() bool {
 	latestVersion := GetCliLatestVersion()
 
 	return latestVersion.GreaterThan(currentVersion)
+}
+
+func HasCliLatestVersion() bool {
+	return !GetCliLatestVersion().Equal(emptyVersion)
 }
 
 func InstalledWithHomebrew() bool {


### PR DESCRIPTION
* Add a `mint update base` command and include it in `mint update`
* Add a `mint resolve leaves` command and include it in `mint resolve`
* Use YAML parsing to make changes to run definitions, not string replacement
* Consolidate file-handling logic in `internal/cli/files.go`
* Clean up duplication